### PR TITLE
Forcing ESLint to look at own node_modules to resolve plugins

### DIFF
--- a/packages/cli/scripts/util/cdkHelpers.js
+++ b/packages/cli/scripts/util/cdkHelpers.js
@@ -178,7 +178,7 @@ async function lint(inputFiles) {
       process.env.NO_COLOR === "true" ? "--no-color" : "--color",
       ...inputFiles,
     ],
-    { stdio: "inherit", cwd: paths.appPath }
+    { stdio: "inherit", cwd: paths.ownPath }
   );
 
   if (response.error) {
@@ -284,6 +284,7 @@ async function transpile(cliInfo) {
 }
 
 function copyConfigFiles() {
+  // Copy this file because we need it in the Lambda build process as well
   return fs.copy(
     path.join(paths.ownPath, "assets", "cdk-wrapper", "eslint.js"),
     path.join(paths.appBuildPath, "eslint.js")


### PR DESCRIPTION
Fixes the issue where npm/yarn doesn't flatten the plugin dependencies if another package in the user's app has conflicting versions. In these cases, ESLint cannot find the plugins or parsers.