### PR TITLE
Stub Lambda should not reconnect to websocket on error code 1006 ENOTFOUND

### DIFF
--- a/packages/resources/lambda/stub/index.js
+++ b/packages/resources/lambda/stub/index.js
@@ -64,7 +64,12 @@ exports.main = function (event, context, callback) {
       }
 
       // reconnect
-      connectAndSendMessage();
+      if (e.code === 1006) {
+        // Do not retry on error 1006. It results from error ENOTFOUND.
+        // ie. debug stack is removed and the websocket endpoint does not exist.
+      } else {
+        connectAndSendMessage();
+      }
     };
 
     _ref.ws.onmessage = (e) => {
@@ -145,7 +150,10 @@ exports.main = function (event, context, callback) {
     }
 
     // handle invalid and expired response
-    if (action !== "client.lambdaResponse" || debugRequestId !== _ref.debugRequestId) {
+    if (
+      action !== "client.lambdaResponse" ||
+      debugRequestId !== _ref.debugRequestId
+    ) {
       console.log("receiveMessage() - discard response");
       return;
     }

--- a/packages/resources/lambda/stub/index.js
+++ b/packages/resources/lambda/stub/index.js
@@ -67,6 +67,7 @@ exports.main = function (event, context, callback) {
       if (e.code === 1006) {
         // Do not retry on error 1006. It results from error ENOTFOUND.
         // ie. debug stack is removed and the websocket endpoint does not exist.
+        _ref.ws = undefined;
       } else {
         connectAndSendMessage();
       }


### PR DESCRIPTION
The stub lambda keeps trying to reconnect to web socket when the debug stack is removed. This prints out a lot of logs and cost $ for CloudWatch Logs.