### PR TITLE
Support --outputs-file option for `sst deploy`

### DIFF
--- a/packages/cli/bin/scripts.js
+++ b/packages/cli/bin/scripts.js
@@ -87,9 +87,9 @@ function addOptions(currentCmd) {
     }
 
     if (currentCmd === cmd.deploy) {
-      yargs.positional("outputs-file", {
+      yargs.option("outputs-file", {
         type: "string",
-        describe: "Path to file where AWS CloudFormation outputs will be written as JSON"
+        describe: "Path to file where stack outputs will be written as JSON"
       });
     }
   };

--- a/packages/cli/bin/scripts.js
+++ b/packages/cli/bin/scripts.js
@@ -89,7 +89,7 @@ function addOptions(currentCmd) {
     if (currentCmd === cmd.deploy) {
       yargs.option("outputs-file", {
         type: "string",
-        describe: "Path to file where stack outputs will be written as JSON"
+        describe: "Path to file where the stack outputs will be written"
       });
     }
   };

--- a/packages/cli/bin/scripts.js
+++ b/packages/cli/bin/scripts.js
@@ -85,6 +85,13 @@ function addOptions(currentCmd) {
         describe: "Specify a stack, if you have multiple stacks",
       });
     }
+
+    if (currentCmd === cmd.deploy) {
+      yargs.positional("outputs-file", {
+        type: "string",
+        describe: "Path to file where AWS CloudFormation outputs will be written as JSON"
+      });
+    }
   };
 }
 

--- a/packages/cli/scripts/deploy.js
+++ b/packages/cli/scripts/deploy.js
@@ -43,10 +43,13 @@ module.exports = async function (argv, config, cliInfo) {
     }
   } while (!isCompleted);
 
-  // Write AWS CloudFormation outputs to json file if the flag --outputs-file is specified
+  // This is native CDK option. According to CDK documentation:
+  // If an outputs file has been specified, create the file path and write stack outputs to it once.
+  // Outputs are written after all stacks have been deployed. If a stack deployment fails,
+  // all of the outputs from successfully deployed stacks before the failure will still be written.
   if (argv.outputsFile) {
     writeOutputsFile(stackStates, path.join(paths.appPath, argv.outputsFile));
-   }
+  }
 
   // Print deploy result
   printResults(stackStates);
@@ -96,14 +99,14 @@ async function writeOutputsFile(stackStates, outputsFileWithPath) {
       return {...acc, [name]: outputs };
     }
     return acc;
-    }, {});
+  }, {});
 
 
-    fs.ensureFileSync(outputsFileWithPath);
-    await fs.writeJson(outputsFileWithPath, stackOutputs, {
-      spaces: 2,
-      encoding: 'utf8',
-    });
+  fs.ensureFileSync(outputsFileWithPath);
+  await fs.writeJson(outputsFileWithPath, stackOutputs, {
+    spaces: 2,
+    encoding: 'utf8',
+  });
 }
 
 function formatStackStatus(status) {

--- a/www/docs/packages/cli.md
+++ b/www/docs/packages/cli.md
@@ -75,7 +75,7 @@ Deploy all your stacks to AWS. Or optionally deploy a specific stack.
 
 - `--outputs-file`
 
-  Pass in the `--outputs-file <filename>` option if you want to write AWS CloudFormation outputs to a JSON file. Works the same way as the `--outputs-file` flag for the cdk.
+  Pass in the `--outputs-file <filename>` option if you want to write AWS CloudFormation stack outputs to a JSON file. Works the same way as the [`--outputs-file`](https://docs.aws.amazon.com/cdk/latest/guide/cli.html#w108aac23b7c33c13) option for AWS CDK.
 
 ### `remove [stack]`
 

--- a/www/docs/packages/cli.md
+++ b/www/docs/packages/cli.md
@@ -71,6 +71,12 @@ Generates a `build/` directory with the compiled files and a `build/cdk.out/` di
 
 Deploy all your stacks to AWS. Or optionally deploy a specific stack.
 
+#### Options
+
+- `--outputs-file`
+
+  Pass in the `--outputs-file <filename>` option if you want to write AWS CloudFormation outputs to a JSON file. Works the same way as the `--outputs-file` flag for the cdk.
+
 ### `remove [stack]`
 
 Remove all your stacks and all of their resources from AWS. Or optionally remove a specific stack. Also removes the debug stack that might've been deployed along with `sst start`.


### PR DESCRIPTION
Add support for writing AWS CloudFormation output to a JSON file with the outputs-file flag on sst deploy.

Closes #94