### PR TITLE
Set the esbuild target based on the current NodeJS runtime or Lambda runtime

### DIFF
--- a/packages/cli/scripts/start.js
+++ b/packages/cli/scripts/start.js
@@ -10,13 +10,14 @@ const spawn = require("cross-spawn");
 const allSettled = require("promise.allsettled");
 const { logger, getChildLogger } = require("@serverless-stack/core");
 
-const sstDeploy = require("./deploy");
 const sstBuild = require("./build");
+const sstDeploy = require("./deploy");
 const paths = require("./util/paths");
 const {
   prepareCdk,
   applyConfig,
   getTsBinPath,
+  getEsbuildTarget,
   deploy: cdkDeploy,
   bootstrap: cdkBootstrap,
 } = require("./util/cdkHelpers");
@@ -594,8 +595,8 @@ async function transpile(srcPath, handler) {
     sourcemap: true,
     platform: "node",
     incremental: true,
-    target: ["es2015"],
     entryPoints: [fullPath],
+    target: [getEsbuildTarget()],
     color: process.env.NO_COLOR !== "true",
     outdir: path.join(paths.appPath, outSrcPath),
   };

--- a/packages/cli/scripts/util/cdkHelpers.js
+++ b/packages/cli/scripts/util/cdkHelpers.js
@@ -29,6 +29,10 @@ async function checkFileExists(file) {
     .catch(() => false);
 }
 
+function getEsbuildTarget() {
+  return "node" + process.version.slice(1);
+}
+
 /**
  * Finds the path to the tsc package executable by converting the file path of:
  * /Users/spongebob/serverless-stack/node_modules/typescript/dist/index.js
@@ -271,6 +275,7 @@ async function transpile(cliInfo) {
 
   logger.info(chalk.grey("Transpiling source"));
 
+  console.log(getEsbuildTarget());
   try {
     await esbuild.build({
       external,
@@ -280,8 +285,8 @@ async function transpile(cliInfo) {
       sourcemap: true,
       platform: "node",
       outdir: buildDir,
-      target: ["es2015"],
       entryPoints: [entryPoint],
+      target: [getEsbuildTarget()],
       tsconfig: isTs ? tsconfig : undefined,
       color: process.env.NO_COLOR !== "true",
     });
@@ -467,4 +472,5 @@ module.exports = {
   getTsBinPath,
   parallelDeploy,
   parallelDestroy,
+  getEsbuildTarget,
 };

--- a/packages/resources/src/util/builder.ts
+++ b/packages/resources/src/util/builder.ts
@@ -3,8 +3,10 @@ import * as path from "path";
 import * as fs from "fs-extra";
 import zipLocal from "zip-local";
 import * as esbuild from "esbuild";
+import * as lambda from "@aws-cdk/aws-lambda";
 
 interface BuilderProps {
+  readonly target: string;
   readonly srcPath: string;
   readonly handler: string;
   readonly bundle: boolean;
@@ -54,7 +56,7 @@ function getHandlerFullPosixPath(srcPath: string, handler: string): string {
 }
 
 export function builder(builderProps: BuilderProps): BuilderOutput {
-  const { srcPath, bundle, handler, buildDir } = builderProps;
+  const { target, bundle, srcPath, handler, buildDir } = builderProps;
 
   console.log(
     chalk.grey(
@@ -155,8 +157,8 @@ export function builder(builderProps: BuilderProps): BuilderOutput {
       format: "cjs",
       sourcemap: true,
       platform: "node",
+      target: [target],
       outdir: buildPath,
-      target: ["es2015"],
       entryPoints: [entryPath],
       color: process.env.NO_COLOR !== "true",
       tsconfig: hasTsconfig ? tsconfig : undefined,


### PR DESCRIPTION
Previously, the target was set to `es2015` — #115. But for some ES syntax, esbuild doesn't transpile down to `es2015` — #136.

Fixes #136 by:

- Setting the CDK and Lambda (`sst start`) target to the current Node version
- And Lambda bundle target to the function runtime that's used