### PR TITLE
Support for JSII

### DIFF
--- a/packages/cli/assets/cdk-wrapper/run.js
+++ b/packages/cli/assets/cdk-wrapper/run.js
@@ -57,6 +57,7 @@ const app = new sst.App({
   lint: config.lint,
   stage: config.stage,
   region: config.region,
+  sstCliPath: config.sstCliPath,
   debugEndpoint: config.debugEndpoint,
 });
 

--- a/packages/cli/scripts/util/cdkHelpers.js
+++ b/packages/cli/scripts/util/cdkHelpers.js
@@ -348,6 +348,7 @@ async function applyConfig(argv) {
     );
   }
 
+  config.sstCliPath = paths.ownPath;
   config.name = config.name || DEFAULT_NAME;
   config.stage = argv.stage || config.stage || DEFAULT_STAGE;
   config.lint = config.lint === false ? false : DEFAULT_LINT;


### PR DESCRIPTION
- [x] Globally install SST `$ npm install -g sst@npm:@serverless-stack/cli`
- [ ] Create Python Lambda sandbox
- [ ] Support other runtimes in `sst.Function`
- [ ] Setup jsii for resources
- [ ] Setup build script to publish to other packages
- [ ] Wrap around the `app.py`
