### PR TITLE
Proposal: Support including extra files with final bundle

### DIFF
--- a/packages/resources/src/Function.ts
+++ b/packages/resources/src/Function.ts
@@ -23,6 +23,10 @@ const runtimeTargetMap = {
 
 export type HandlerProps = FunctionHandlerProps;
 export type FunctionDefinition = string | Function | FunctionProps;
+export type Include = {
+  from: string;
+  to: string;
+};
 
 export interface FunctionProps extends Omit<lambda.FunctionOptions, "timeout"> {
   /**
@@ -68,6 +72,11 @@ export interface FunctionProps extends Omit<lambda.FunctionOptions, "timeout"> {
    * @default - Defaults to true
    */
   readonly bundle?: boolean;
+
+  /**
+   * Include additional files in bundle
+   */
+  readonly include?: Include[];
 }
 
 /**
@@ -97,6 +106,7 @@ export class Function extends lambda.Function {
     const tracing = props.tracing || lambda.Tracing.ACTIVE;
     const runtime = props.runtime || lambda.Runtime.NODEJS_12_X;
     const bundle = props.bundle === undefined ? true : props.bundle;
+    const include = props.include || [];
 
     // Validate handler
     if (!handler) {
@@ -141,6 +151,7 @@ export class Function extends lambda.Function {
         handler,
         target: esbuildTarget,
         buildDir: root.buildDir,
+        include: include,
       });
       super(scope, id, {
         ...props,

--- a/packages/resources/src/util/builder.ts
+++ b/packages/resources/src/util/builder.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as fs from "fs-extra";
 import zipLocal from "zip-local";
 import * as esbuild from "esbuild";
+import type { Include } from "../Function";
 
 interface BuilderProps {
   readonly target: string;
@@ -10,6 +11,7 @@ interface BuilderProps {
   readonly handler: string;
   readonly bundle: boolean;
   readonly buildDir: string;
+  readonly include: Include[];
 }
 
 interface BuilderOutput {
@@ -55,7 +57,7 @@ function getHandlerFullPosixPath(srcPath: string, handler: string): string {
 }
 
 export function builder(builderProps: BuilderProps): BuilderOutput {
-  const { target, bundle, srcPath, handler, buildDir } = builderProps;
+  const { target, bundle, srcPath, handler, buildDir, include } = builderProps;
 
   console.log(
     chalk.grey(
@@ -134,6 +136,12 @@ export function builder(builderProps: BuilderProps): BuilderOutput {
   const external = getAllExternalsForHandler(srcPath, bundle);
 
   transpile(entryPath);
+
+  for (const i of include) {
+    fs.copySync(i.from, path.join(buildPath, i.to), {
+      recursive: true,
+    });
+  }
 
   let outZip, outHandler;
   if (bundle) {


### PR DESCRIPTION
Decided to mock it up in actual code to demonstrate how it could work.  Basically I need to add some supporting files with my bundles (native libraries for example) for my function to work properly so I thought SST could support an `includes` parameter.

Usage:

```
    const api = new sst.Api(this, "Api", {
      defaultFunctionProps: {
        include: [
          {from: "node_modules/.prisma/client/prisma.schema", to: "prisma.schema"},
        ],
      }
    })
```
