### PR TITLE
Support attaching Function invoke permissions

### DIFF
--- a/packages/resources/src/util/permission.ts
+++ b/packages/resources/src/util/permission.ts
@@ -7,6 +7,7 @@ import { Api } from "../Api";
 import { Table } from "../Table";
 import { Topic } from "../Topic";
 import { Queue } from "../Queue";
+import { Function } from "../Function";
 import { Stack } from "../Stack";
 import { isConstructOf } from "./construct";
 
@@ -114,6 +115,8 @@ export function attachPermissionsToRole(
       role.addToPolicy(buildPolicy("sns:*", [permission.snsTopic.topicArn]));
     } else if (permission instanceof Queue) {
       role.addToPolicy(buildPolicy("sqs:*", [permission.sqsQueue.queueArn]));
+    } else if (permission instanceof Function) {
+      role.addToPolicy(buildPolicy("lambda:*", [permission.functionArn]));
     }
     ////////////////////////////////////
     // Case: grant method

--- a/packages/resources/test/Function.test.ts
+++ b/packages/resources/test/Function.test.ts
@@ -91,6 +91,10 @@ test("xray-disabled", async () => {
   });
 });
 
+/////////////////////////////
+// Test attachPermissions - generic
+/////////////////////////////
+
 test("attachPermission-string-all", async () => {
   const stack = new Stack(new App(), "stack");
   const f = new Function(stack, "Function", {
@@ -150,7 +154,7 @@ test("attachPermission-array-string", async () => {
   });
 });
 
-test("attachPermission-array-cfn-sst-api", async () => {
+test("attachPermission-array-sst-api", async () => {
   const stack = new Stack(new App(), "stack");
   const api = new Api(stack, "Api", {
     routes: { "GET /": "test/lambda.handler" },
@@ -185,7 +189,7 @@ test("attachPermission-array-cfn-sst-api", async () => {
   });
 });
 
-test("attachPermission-array-cfn-sst-function", async () => {
+test("attachPermission-array-sst-function", async () => {
   const stack = new Stack(new App(), "stack");
   const f = new Function(stack, "functionA", {
     handler: "test/lambda.handler",
@@ -209,7 +213,6 @@ test("attachPermission-array-cfn-sst-function", async () => {
     },
   });
 });
-
 
 test("attachPermission-array-cfn-construct-sns", async () => {
   const stack = new Stack(new App(), "stack");
@@ -353,6 +356,10 @@ test("attachPermission-policy-statement", async () => {
     },
   });
 });
+
+/////////////////////////////
+// Test fromDefinition
+/////////////////////////////
 
 test("fromDefinition-string", async () => {
   const stack = new Stack(new App(), "stack");

--- a/packages/resources/test/Function.test.ts
+++ b/packages/resources/test/Function.test.ts
@@ -185,6 +185,32 @@ test("attachPermission-array-cfn-sst-api", async () => {
   });
 });
 
+test("attachPermission-array-cfn-sst-function", async () => {
+  const stack = new Stack(new App(), "stack");
+  const f = new Function(stack, "functionA", {
+    handler: "test/lambda.handler",
+  });
+  const f2 = new Function(stack, "functionB", {
+    handler: "test/lambda.handler",
+  });
+  f.attachPermissions([f2]);
+
+  expect(stack).toHaveResource("AWS::IAM::Policy", {
+    PolicyDocument: {
+      Statement: [
+        lambdaDefaultPolicy,
+        {
+          Action: "lambda:*",
+          Effect: "Allow",
+          Resource: { "Fn::GetAtt": ["functionB93D70A66", "Arn"] },
+        },
+      ],
+      Version: "2012-10-17",
+    },
+  });
+});
+
+
 test("attachPermission-array-cfn-construct-sns", async () => {
   const stack = new Stack(new App(), "stack");
   const topic = new sns.Topic(stack, "Topic");

--- a/www/docs/constructs/Function.md
+++ b/www/docs/constructs/Function.md
@@ -86,7 +86,7 @@ new sst.Function(this, "MyApiLambda", {
 });
 ```
 
-### Using SSM vales as environment variables
+### Using SSM values as environment variables
 
 ```js
 import * as ssm from "@aws-cdk/aws-ssm";

--- a/www/docs/constructs/Function.md
+++ b/www/docs/constructs/Function.md
@@ -161,6 +161,7 @@ const fun = new Function(this, "Function", { handler: "src/lambda.main" });
    - [Topic](Topic.md)
    - [Table](Table.md)
    - [Queue](Queue.md)
+   - [Function](Function.md)
    - [cdk.aws-sns.Topic](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-sns.Topic.html)
    - [cdk.aws-s3.Bucket](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-s3.Bucket.html)
    - [cdk.aws-sqs.Queue](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-sqs.Queue.html)


### PR DESCRIPTION
This is one way to add support for issue #256. 

This change would make it possible to give Functions permissions to invoke other Functions:

```js
const sns = new sns.Topic(this, "Topic");
const table = new sst.Table(this, "Table");
const moreFun =  new sst.Function(this, "MyLambda", {
      handler: "src/myLambda.main"
    });

fun.attachPermissions([sns, table, moreFun]);
```

