### PR TITLE
Support passing jest configs to sst test

### DIFF
--- a/packages/cli/scripts/test.js
+++ b/packages/cli/scripts/test.js
@@ -20,15 +20,20 @@ let argv = process.argv.slice(2);
 const createJestConfig = require("./util/createJestConfig");
 const path = require("path");
 const paths = require("./util/paths");
-argv.push(
-  "--config",
-  JSON.stringify(
-    createJestConfig(
-      (relativePath) => path.resolve(__dirname, "..", relativePath),
-      path.resolve(paths.appPath)
+
+const configPassed = argv.some(a => ["--config", "-c"].includes(a));
+if (!configPassed) {
+  argv.push(
+    "--config",
+    JSON.stringify(
+      createJestConfig(
+        (relativePath) => path.resolve(__dirname, "..", relativePath),
+        path.resolve(paths.appPath)
+      )
     )
-  )
-);
+  );
+}
+
 
 // This is a very dirty workaround for https://github.com/facebook/jest/issues/5913.
 // We're trying to resolve the environment ourselves because Jest does it incorrectly.


### PR DESCRIPTION
Motivation: My team recently migrated a repo from Serverless Framework to SST and naturally our TS compiler started complaining about our test files. This tiny change would allow developers to pass their jest-config to SST's jest-cli process via `sst test`, otherwise we would simply need to set up a direct jest dependency and test script ourselves.