### PR TITLE
Function doc line to reference default func props

### DIFF
--- a/www/docs/constructs/Function.md
+++ b/www/docs/constructs/Function.md
@@ -81,7 +81,7 @@ Refer to the properties made available by [`cdk.lambda.Function`](https://docs.a
 
 ## Default Properties
 
-If you have properties that pertain to all functions, they can be set on the App construct using [default function props](https://docs.serverless-stack.com/constructs/App#specifying-default-function-prop)
+If you have properties that need to be applied to all the functions in your app, they can be set on the App construct using the [`setDefaultFunctionProps`](constructs/App.md#specifying-default-function-prop) method.
 
 ## Methods
 

--- a/www/docs/constructs/Function.md
+++ b/www/docs/constructs/Function.md
@@ -79,6 +79,10 @@ new Function(this, "MyApiLambda", {
 
 Refer to the properties made available by [`cdk.lambda.Function`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda.Function.html#properties).
 
+## Default Properties
+
+If you have properties that pertain to all functions, they can be set on the App construct using [default function props](https://docs.serverless-stack.com/constructs/App#specifying-default-function-prop)
+
 ## Methods
 
 An instance of `Function` contains the following methods.


### PR DESCRIPTION
Adds an additional line to the documentation in the Function construct to point the reader to App for the setting of default function properties