### PR TITLE
SST equivalent of a SLS local invocation

### DIFF
--- a/www/docs/migrating-from-serverless-framework.md
+++ b/www/docs/migrating-from-serverless-framework.md
@@ -282,9 +282,9 @@ SST also supports the `IS_LOCAL` environment variable that gets set in your Lamb
 
 ### Invoking locally
 
-With the Serverless Framework before you would need to run the following command `serverless invoke local -f function_name` to run a function locally. 
+With the Serverless Framework you need to run the following command `serverless invoke local -f function_name` to invoke a function locally. 
 
-With SST this can be done via PostMan, Hopscotch, curl or any other API client. However with this event you are actually sending a request to API Gateway which then invokes your Lambda.
+With SST this can be done via PostMan, Hopscotch, curl or any other API client. However, with this event you are actually sending a request to API Gateway which then invokes your Lambda.
 
 ## CI/CD
 

--- a/www/docs/migrating-from-serverless-framework.md
+++ b/www/docs/migrating-from-serverless-framework.md
@@ -280,6 +280,12 @@ A lot of the commands that you are used to using in Serverless Framework transla
 
 SST also supports the `IS_LOCAL` environment variable that gets set in your Lambda functions when run locally.
 
+### Invoking locally
+
+With the Serverless Framework before you would need to run the following command `serverless invoke local -f function_name` to run a function locally. 
+
+With SST this can be done via PostMan, Hopsctoch or any other API client. However with this event you are actually sending a request to API Gateway ehich then invokes your Lambda. 
+
 ## CI/CD
 
 If you are using GitHub Actions, Circle CI, etc., to deploy Serverless Framework apps, you can now add the SST versions to your build scripts.

--- a/www/docs/migrating-from-serverless-framework.md
+++ b/www/docs/migrating-from-serverless-framework.md
@@ -284,7 +284,7 @@ SST also supports the `IS_LOCAL` environment variable that gets set in your Lamb
 
 With the Serverless Framework before you would need to run the following command `serverless invoke local -f function_name` to run a function locally. 
 
-With SST this can be done via PostMan, Hopsctoch or any other API client. However with this event you are actually sending a request to API Gateway ehich then invokes your Lambda. 
+With SST this can be done via PostMan, Hopscotch, curl or any other API client. However with this event you are actually sending a request to API Gateway which then invokes your Lambda.
 
 ## CI/CD
 


### PR DESCRIPTION
A while back I asked the following question:

What is the  SST equivalent of the following command to be able to mock the SST API :
```
$ serverless invoke local --function get --path mocks/get-event.json
```

In my PR I just added a section on how to go about.  