### PR TITLE
AppSyncApi: create resolver from the api not datasource

### DIFF
--- a/packages/resources/src/AppSyncApi.ts
+++ b/packages/resources/src/AppSyncApi.ts
@@ -357,7 +357,8 @@ export class AppSyncApi extends cdk.Construct {
     ///////////////////
     // Create resolver
     ///////////////////
-    const resolver = dataSource.createResolver({
+    const resolver = this.graphqlApi.createResolver({
+      dataSource,
       typeName,
       fieldName,
       ...resolverProps,


### PR DESCRIPTION
close #417

Creating a resolver from a data source results in the inability to update that resolver data source later. 
https://github.com/aws/aws-cdk/pull/12973 was merged to revert allowing resolvers to be created against the API.

This change creates the resolver from the AppSync graphqlApi API which allows you to update the resolver in place.
