### PR TITLE
Replace dynamodbTable property with s3Bucket

### DIFF
--- a/www/docs/constructs/StaticSite.md
+++ b/www/docs/constructs/StaticSite.md
@@ -163,7 +163,7 @@ new StaticSite(this, "ReactSite", {
   path: "path/to/site",
   buildCommand: "npm run build",
   buildOutput: "build",
-  dynamodbTable: {
+  s3Bucket: {
     removalPolicy: RemovalPolicy.DESTROY,
   },
 });


### PR DESCRIPTION
Under the "Configure the internally created CDK Bucket instance" section the dynamdbTable property appears to be a typo and should be s3Bucket.