### PR TITLE
StaticSite: update typo tableName to bucketName

### DIFF
--- a/www/docs/constructs/StaticSite.md
+++ b/www/docs/constructs/StaticSite.md
@@ -236,7 +236,7 @@ _Type_: `string`
 
 The ARN of the internally created CDK `Bucket` instance.
 
-### tableName
+### bucketName
 
 _Type_: `string`
 


### PR DESCRIPTION
Looks like the property tableName is supposed to be bucketName. 