### PR TITLE
Allow using Code param

### DIFF
--- a/packages/resources/src/Function.ts
+++ b/packages/resources/src/Function.ts
@@ -58,6 +58,15 @@ export interface FunctionProps
    */
   readonly runtime?: string | lambda.Runtime;
   /**
+   * The source code of your Lambda function.
+   *
+   * You can point to a file in an
+   * Amazon Simple Storage Service (Amazon S3) bucket or specify your source
+   * code as inline text.
+   *
+   */
+  readonly code?: lambda.Code;
+  /**
    * The amount of memory in MB allocated.
    *
    * @default - Defaults to 1024
@@ -134,6 +143,7 @@ export class Function extends lambda.Function {
     const memorySize = props.memorySize || 1024;
     const tracing = props.tracing || lambda.Tracing.ACTIVE;
     let runtime = props.runtime || lambda.Runtime.NODEJS_12_X;
+    const code = props.code;
     let bundle = props.bundle;
     const permissions = props.permissions;
 
@@ -241,6 +251,18 @@ export class Function extends lambda.Function {
         runtime: lambda.Runtime.NODEJS_12_X,
         handler: "placeholder",
         code: new lambda.InlineCode("placeholder"),
+        timeout,
+      });
+    }
+    // Take code already built for us
+    else if (code) {
+      super(scope, id, {
+        ...props,
+        runtime,
+        tracing,
+        memorySize,
+        handler,
+        code,
         timeout,
       });
     }

--- a/packages/resources/test/Function.test.ts
+++ b/packages/resources/test/Function.test.ts
@@ -143,6 +143,18 @@ test("runtime-class-invalid", async () => {
   }).toThrow(/The specified runtime is not supported/);
 });
 
+test("code-inline-placeholder", async () => {
+  const stack = new Stack(new App(), "stack");
+  new Function(stack, "Function", {
+    handler: "test/lambda.handler",
+    runtime: "nodejs10.x",
+    code: new lambda.InlineCode("placeholder"),
+  });
+  expect(stack).toHaveResource("AWS::Lambda::Function", {
+    Runtime: "nodejs10.x",
+  });
+});
+
 test("timeout-number", async () => {
   const stack = new Stack(new App(), "stack");
   new Function(stack, "Function", {


### PR DESCRIPTION
We are somewhat limited by what we can do with the current builders.  By allowing the developer to pass in a Code object, they can create their lambda however they want.

This is a somewhat naive implementation that I'm happy to talk about.