### PR TITLE
Support esbuild config in sst config

### DIFF
--- a/packages/cli/assets/cdk-wrapper/run.js
+++ b/packages/cli/assets/cdk-wrapper/run.js
@@ -67,6 +67,7 @@ const app = new sst.App({
   region: config.region,
   typeCheck: config.typeCheck,
   skipBuild: config.skipBuild,
+  esbuildConfig: config.esbuildConfig,
   debugEndpoint: config.debugEndpoint,
   debugBucketArn: config.debugBucketArn,
   debugBucketName: config.debugBucketName,

--- a/packages/cli/bin/scripts.js
+++ b/packages/cli/bin/scripts.js
@@ -64,6 +64,7 @@ const DEFAULT_NAME = "my-app";
 const DEFAULT_REGION = "us-east-1";
 const DEFAULT_LINT = true;
 const DEFAULT_TYPE_CHECK = true;
+const DEFAULT_ESBUILD_CONFIG = undefined;
 
 function getCliInfo() {
   const usingYarn = fs.existsSync(path.join(paths.appPath, "yarn.lock"));
@@ -168,6 +169,7 @@ function applyConfig(argv) {
   config.lint = config.lint === false ? false : DEFAULT_LINT;
   config.region = argv.region || config.region || DEFAULT_REGION;
   config.typeCheck = config.typeCheck === false ? false : DEFAULT_TYPE_CHECK;
+  config.esbuildConfig = config.esbuildConfig || DEFAULT_ESBUILD_CONFIG;
 
   return config;
 }

--- a/packages/cli/test/config-esbuildconfig-invalid/config-esbuildconfig-invalid.test.js
+++ b/packages/cli/test/config-esbuildconfig-invalid/config-esbuildconfig-invalid.test.js
@@ -1,0 +1,20 @@
+const { runBuildCommand, clearBuildOutput } = require("../helpers");
+
+beforeEach(async () => {
+  await clearBuildOutput(__dirname);
+});
+
+afterAll(async () => {
+  await clearBuildOutput(__dirname);
+});
+
+/**
+ * Test that the synth command ran successfully
+ */
+test("config-esbuildconfig-invalid", async () => {
+  const result = await runBuildCommand(__dirname);
+
+  expect(result).toMatch(
+    /Bad esbuild configuration/
+  );
+});

--- a/packages/cli/test/config-esbuildconfig-invalid/esbuild-config.js
+++ b/packages/cli/test/config-esbuildconfig-invalid/esbuild-config.js
@@ -1,0 +1,1 @@
+throw new Error("Bad esbuild configuration");

--- a/packages/cli/test/config-esbuildconfig-invalid/lib/index.js
+++ b/packages/cli/test/config-esbuildconfig-invalid/lib/index.js
@@ -1,0 +1,1 @@
+export default function main() {}

--- a/packages/cli/test/config-esbuildconfig-invalid/package.json
+++ b/packages/cli/test/config-esbuildconfig-invalid/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@serverless-stack/cli-test-config-esbuildconfig-invalid",
+  "private": true,
+  "description": "tests",
+  "version": "0.34.0",
+  "scripts": {
+    "build": "sst build"
+  },
+  "dependencies": {
+    "@serverless-stack/cli": "^0.34.0",
+    "@serverless-stack/resources": "^0.34.0"
+  },
+  "license": "ISC"
+}

--- a/packages/cli/test/config-esbuildconfig-invalid/sst.json
+++ b/packages/cli/test/config-esbuildconfig-invalid/sst.json
@@ -1,0 +1,7 @@
+{
+    "type": "@serverless-stack/resources",
+    "name": "config-esbuildconfig-invalid",
+    "stage": "prod-jest",
+    "region": "us-west-2",
+    "esbuildConfig": "esbuild-config.js"
+}

--- a/packages/cli/test/config-esbuildconfig-non-plugins/config-esbuildconfig-non-plugins.test.js
+++ b/packages/cli/test/config-esbuildconfig-non-plugins/config-esbuildconfig-non-plugins.test.js
@@ -1,0 +1,21 @@
+const { runBuildCommand, clearBuildOutput } = require("../helpers");
+
+beforeEach(async () => {
+  await clearBuildOutput(__dirname);
+});
+
+afterAll(async () => {
+  await clearBuildOutput(__dirname);
+});
+
+/**
+ * Test that the synth command ran successfully
+ */
+test("config-esbuildconfig-non-plugins", async () => {
+  const result = await runBuildCommand(__dirname);
+
+  expect(result).toContain("Esbuild config loaded");
+  expect(result).toMatch(
+    /Cannot configure the "dummy" option/
+  );
+});

--- a/packages/cli/test/config-esbuildconfig-non-plugins/esbuild-config.js
+++ b/packages/cli/test/config-esbuildconfig-non-plugins/esbuild-config.js
@@ -1,0 +1,4 @@
+console.log("Esbuild config loaded");
+module.exports = {
+  dummy: true
+};

--- a/packages/cli/test/config-esbuildconfig-non-plugins/lib/index.js
+++ b/packages/cli/test/config-esbuildconfig-non-plugins/lib/index.js
@@ -1,0 +1,1 @@
+export default function main() {}

--- a/packages/cli/test/config-esbuildconfig-non-plugins/package.json
+++ b/packages/cli/test/config-esbuildconfig-non-plugins/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@serverless-stack/cli-test-config-esbuildconfig-non-plugins",
+  "private": true,
+  "description": "tests",
+  "version": "0.34.0",
+  "scripts": {
+    "build": "sst build"
+  },
+  "dependencies": {
+    "@serverless-stack/cli": "^0.34.0",
+    "@serverless-stack/resources": "^0.34.0"
+  },
+  "license": "ISC"
+}

--- a/packages/cli/test/config-esbuildconfig-non-plugins/sst.json
+++ b/packages/cli/test/config-esbuildconfig-non-plugins/sst.json
@@ -1,5 +1,5 @@
 {
-    "name": "config-esbuildconfig-invalid",
+    "name": "config-esbuildconfig-non-plugins",
     "stage": "prod",
     "region": "us-west-2",
     "esbuildConfig": "esbuild-config.js"

--- a/packages/cli/test/config-esbuildconfig-not-found/config-esbuildconfig-not-found.test.js
+++ b/packages/cli/test/config-esbuildconfig-not-found/config-esbuildconfig-not-found.test.js
@@ -1,0 +1,20 @@
+const { runBuildCommand, clearBuildOutput } = require("../helpers");
+
+beforeEach(async () => {
+  await clearBuildOutput(__dirname);
+});
+
+afterAll(async () => {
+  await clearBuildOutput(__dirname);
+});
+
+/**
+ * Test that the synth command ran successfully
+ */
+test("config-esbuildconfig-not-found", async () => {
+  const result = await runBuildCommand(__dirname);
+
+  expect(result).toMatch(
+    /Cannot find the esbuild config file at.*file-that-does-not-exist/
+  );
+});

--- a/packages/cli/test/config-esbuildconfig-not-found/lib/index.js
+++ b/packages/cli/test/config-esbuildconfig-not-found/lib/index.js
@@ -1,0 +1,1 @@
+export default function main() {}

--- a/packages/cli/test/config-esbuildconfig-not-found/package.json
+++ b/packages/cli/test/config-esbuildconfig-not-found/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@serverless-stack/cli-test-config-esbuildconfig-not-found",
+  "private": true,
+  "description": "tests",
+  "version": "0.34.0",
+  "scripts": {
+    "build": "sst build"
+  },
+  "dependencies": {
+    "@serverless-stack/cli": "^0.34.0",
+    "@serverless-stack/resources": "^0.34.0"
+  },
+  "license": "ISC"
+}

--- a/packages/cli/test/config-esbuildconfig-not-found/sst.json
+++ b/packages/cli/test/config-esbuildconfig-not-found/sst.json
@@ -1,0 +1,7 @@
+{
+    "type": "@serverless-stack/resources",
+    "name": "config-esbuildconfig-not-found",
+    "stage": "prod-jest",
+    "region": "us-west-2",
+    "esbuildConfig": "file-that-does-not-exist"
+}

--- a/packages/cli/test/config-esbuildconfig-not-found/sst.json
+++ b/packages/cli/test/config-esbuildconfig-not-found/sst.json
@@ -1,7 +1,6 @@
 {
-    "type": "@serverless-stack/resources",
     "name": "config-esbuildconfig-not-found",
-    "stage": "prod-jest",
+    "stage": "prod",
     "region": "us-west-2",
     "esbuildConfig": "file-that-does-not-exist"
 }

--- a/packages/cli/test/config-esbuildconfig-not-set/config-esbuildconfig-not-set.test.js
+++ b/packages/cli/test/config-esbuildconfig-not-set/config-esbuildconfig-not-set.test.js
@@ -1,0 +1,18 @@
+const { runBuildCommand, clearBuildOutput } = require("../helpers");
+
+beforeEach(async () => {
+  await clearBuildOutput(__dirname);
+});
+
+afterAll(async () => {
+  await clearBuildOutput(__dirname);
+});
+
+/**
+ * Test that the synth command ran successfully
+ */
+test("config-esbuildconfig-not-set", async () => {
+  const result = await runBuildCommand(__dirname);
+  expect(result).not.toContain("Esbuild config loaded");
+  expect(result).toContain("prod-jest-config-esbuildconfig-not-set-sample");
+});

--- a/packages/cli/test/config-esbuildconfig-not-set/config-esbuildconfig-not-set.test.js
+++ b/packages/cli/test/config-esbuildconfig-not-set/config-esbuildconfig-not-set.test.js
@@ -14,5 +14,5 @@ afterAll(async () => {
 test("config-esbuildconfig-not-set", async () => {
   const result = await runBuildCommand(__dirname);
   expect(result).not.toContain("Esbuild config loaded");
-  expect(result).toContain("prod-jest-config-esbuildconfig-not-set-sample");
+  expect(result).toContain("prod-config-esbuildconfig-not-set-sample");
 });

--- a/packages/cli/test/config-esbuildconfig-not-set/esbuild-config.js
+++ b/packages/cli/test/config-esbuildconfig-not-set/esbuild-config.js
@@ -1,0 +1,2 @@
+console.log("Esbuild config loaded");
+module.exports = {};

--- a/packages/cli/test/config-esbuildconfig-not-set/lib/index.ts
+++ b/packages/cli/test/config-esbuildconfig-not-set/lib/index.ts
@@ -1,0 +1,14 @@
+import * as sst from "@serverless-stack/resources";
+
+class MySampleStack extends sst.Stack {
+  constructor(scope: sst.App, id: string, props?: sst.StackProps) {
+    super(scope, id, props);
+
+    // Create an SNS topic
+    new sst.Topic(this, "MyTopic", {});
+  }
+}
+
+export default function main(app: sst.App): void {
+  new MySampleStack(app, "sample");
+}

--- a/packages/cli/test/config-esbuildconfig-not-set/package.json
+++ b/packages/cli/test/config-esbuildconfig-not-set/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@serverless-stack/cli-test-config-esbuildconfig-not-set",
+  "private": true,
+  "description": "tests",
+  "version": "0.34.0",
+  "scripts": {
+    "build": "sst build"
+  },
+  "dependencies": {
+    "@serverless-stack/cli": "^0.34.0",
+    "@serverless-stack/resources": "^0.34.0"
+  },
+  "license": "ISC"
+}

--- a/packages/cli/test/config-esbuildconfig-not-set/sst.json
+++ b/packages/cli/test/config-esbuildconfig-not-set/sst.json
@@ -1,0 +1,6 @@
+{
+    "type": "@serverless-stack/resources",
+    "name": "config-esbuildconfig-not-set",
+    "stage": "prod-jest",
+    "region": "us-west-2"
+}

--- a/packages/cli/test/config-esbuildconfig-not-set/sst.json
+++ b/packages/cli/test/config-esbuildconfig-not-set/sst.json
@@ -1,6 +1,5 @@
 {
-    "type": "@serverless-stack/resources",
     "name": "config-esbuildconfig-not-set",
-    "stage": "prod-jest",
+    "stage": "prod",
     "region": "us-west-2"
 }

--- a/packages/cli/test/config-esbuildconfig-not-set/tsconfig.json
+++ b/packages/cli/test/config-esbuildconfig-not-set/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "commonjs",
+    "lib": ["es2018"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "include": ["lib"]
+}

--- a/packages/cli/test/config-esbuildconfig/config-esbuildconfig.test.js
+++ b/packages/cli/test/config-esbuildconfig/config-esbuildconfig.test.js
@@ -1,0 +1,18 @@
+const { runBuildCommand, clearBuildOutput } = require("../helpers");
+
+beforeEach(async () => {
+  await clearBuildOutput(__dirname);
+});
+
+afterAll(async () => {
+  await clearBuildOutput(__dirname);
+});
+
+/**
+ * Test that the synth command ran successfully
+ */
+test("config-esbuildconfig", async () => {
+  const result = await runBuildCommand(__dirname);
+  expect(result).toContain("Esbuild config loaded");
+  expect(result).toContain("prod-jest-config-esbuildconfig-sample");
+});

--- a/packages/cli/test/config-esbuildconfig/config-esbuildconfig.test.js
+++ b/packages/cli/test/config-esbuildconfig/config-esbuildconfig.test.js
@@ -14,5 +14,5 @@ afterAll(async () => {
 test("config-esbuildconfig", async () => {
   const result = await runBuildCommand(__dirname);
   expect(result).toContain("Esbuild config loaded");
-  expect(result).toContain("prod-jest-config-esbuildconfig-sample");
+  expect(result).toContain("prod-config-esbuildconfig-sample");
 });

--- a/packages/cli/test/config-esbuildconfig/esbuild-config.js
+++ b/packages/cli/test/config-esbuildconfig/esbuild-config.js
@@ -1,0 +1,2 @@
+console.log("Esbuild config loaded");
+module.exports = {};

--- a/packages/cli/test/config-esbuildconfig/lib/index.ts
+++ b/packages/cli/test/config-esbuildconfig/lib/index.ts
@@ -1,0 +1,14 @@
+import * as sst from "@serverless-stack/resources";
+
+class MySampleStack extends sst.Stack {
+  constructor(scope: sst.App, id: string, props?: sst.StackProps) {
+    super(scope, id, props);
+
+    // Create an SNS topic
+    new sst.Topic(this, "MyTopic", {});
+  }
+}
+
+export default function main(app: sst.App): void {
+  new MySampleStack(app, "sample");
+}

--- a/packages/cli/test/config-esbuildconfig/package.json
+++ b/packages/cli/test/config-esbuildconfig/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@serverless-stack/cli-test-config-esbuildconfig",
+  "private": true,
+  "description": "tests",
+  "version": "0.34.0",
+  "scripts": {
+    "build": "sst build"
+  },
+  "dependencies": {
+    "@serverless-stack/cli": "^0.34.0",
+    "@serverless-stack/resources": "^0.34.0"
+  },
+  "license": "ISC"
+}

--- a/packages/cli/test/config-esbuildconfig/sst.json
+++ b/packages/cli/test/config-esbuildconfig/sst.json
@@ -1,0 +1,7 @@
+{
+    "type": "@serverless-stack/resources",
+    "name": "config-esbuildconfig",
+    "stage": "prod-jest",
+    "region": "us-west-2",
+    "esbuildConfig": "esbuild-config.js"
+}

--- a/packages/cli/test/config-esbuildconfig/sst.json
+++ b/packages/cli/test/config-esbuildconfig/sst.json
@@ -1,7 +1,6 @@
 {
-    "type": "@serverless-stack/resources",
     "name": "config-esbuildconfig",
-    "stage": "prod-jest",
+    "stage": "prod",
     "region": "us-west-2",
     "esbuildConfig": "esbuild-config.js"
 }

--- a/packages/cli/test/config-esbuildconfig/tsconfig.json
+++ b/packages/cli/test/config-esbuildconfig/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "commonjs",
+    "lib": ["es2018"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "include": ["lib"]
+}

--- a/packages/resources/src/App.ts
+++ b/packages/resources/src/App.ts
@@ -84,6 +84,7 @@ export interface AppDeployProps {
   readonly typeCheck?: boolean;
   readonly buildDir?: string;
   readonly skipBuild?: boolean;
+  readonly esbuildConfig?: string;
   readonly debugEndpoint?: string;
   readonly debugBucketArn?: string;
   readonly debugBucketName?: string;
@@ -118,6 +119,7 @@ export class App extends cdk.App {
   public readonly account: string;
   public readonly typeCheck: boolean;
   public readonly buildDir: string;
+  public readonly esbuildConfig?: string;
   public readonly debugEndpoint?: string;
   public readonly debugBucketArn?: string;
   public readonly debugBucketName?: string;
@@ -162,6 +164,7 @@ export class App extends cdk.App {
     this.lint = deployProps.lint === false ? false : true;
     this.account = process.env.CDK_DEFAULT_ACCOUNT || "my-account";
     this.typeCheck = deployProps.typeCheck === false ? false : true;
+    this.esbuildConfig = deployProps.esbuildConfig;
     this.buildDir = deployProps.buildDir || ".build";
     this.skipBuild = deployProps.skipBuild || false;
     this.defaultFunctionProps = [];

--- a/packages/resources/src/Function.ts
+++ b/packages/resources/src/Function.ts
@@ -272,6 +272,7 @@ export class Function extends lambda.Function {
           handler,
           runtime,
           buildDir: root.buildDir,
+          esbuildConfig: root.esbuildConfig,
         });
         outCode = ret.outCode;
         outHandler = ret.outHandler;

--- a/packages/resources/test/Function.test.ts
+++ b/packages/resources/test/Function.test.ts
@@ -222,6 +222,17 @@ test("bundle: esbuildConfig", async () => {
   expect(stack).toCountResources("AWS::Lambda::Function", 1);
 });
 
+test("bundle: esbuildConfig (from config)", async () => {
+  const app = new App({
+    esbuildConfig: "test/function/esbuild-config.js"
+  });
+  const stack = new Stack(app, "stack");
+  new Function(stack, "Function", {
+    handler: "test/lambda.handler",
+  });
+  expect(stack).toCountResources("AWS::Lambda::Function", 1);
+});
+
 test("bundle: esbuildConfig error invalid plugin", async () => {
   const stack = new Stack(new App(), "stack");
   expect(() => {
@@ -230,6 +241,18 @@ test("bundle: esbuildConfig error invalid plugin", async () => {
       bundle: {
         esbuildConfig: "test/function/esbuild-config-invalid.js"
       },
+    });
+  }).toThrow(/There was a problem transpiling the Lambda handler./);
+});
+
+test("bundle: esbuildConfig error invalid plugin (from config)", async () => {
+  const app = new App({
+    esbuildConfig: "test/function/esbuild-config-invalid.js"
+  });
+  const stack = new Stack(app, "stack");
+  expect(() => {
+    new Function(stack, "Function", {
+      handler: "test/lambda.handler",
     });
   }).toThrow(/There was a problem transpiling the Lambda handler./);
 });

--- a/www/docs/installation.md
+++ b/www/docs/installation.md
@@ -179,7 +179,8 @@ Your SST app also includes a config file in `sst.json`.
   "stage": "dev",
   "region": "us-east-1",
   "lint": true,
-  "typeCheck": true
+  "typeCheck": true,
+  "esbuildConfig": "config/esbuild.js"
 }
 ```
 
@@ -188,6 +189,22 @@ The **stage** and the **region** are defaults for your app and can be overridden
 For JavaScript and TypeScript apps, SST automatically lints your CDK and Lambda function code using [ESLint](https://eslint.org). The **lint** option allows you to turn this off.
 
 For TypeScript apps, SST also automatically type checks your CDK and Lambda function code using [tsc](https://www.typescriptlang.org). The **typeCheck** option allows you to turn this off.
+
+SST automatically transpiles your ES (and TypeScript) code using [esbuild](https://esbuild.github.io/). To use an esbuild plugin install the plugin npm package in your project. Then create a config file that exports the plugin.
+
+```js title="config/esbuild.js"
+const { esbuildDecorators } = require("@anatine/esbuild-decorators");
+
+module.exports = {
+  plugins: [
+    esbuildDecorators(),
+  ]
+};
+```
+
+:::note
+Only the "plugins" option in the esbuild config is currently supported.
+:::
 
 You'll be able to access the stage, region, and name of your app in `lib/index.js`.
 


### PR DESCRIPTION
We use esbuild to build the entire app, not just the NodeJS functions.  Some constructs can benefit from the use of things like decorators (generators for example).

After discussing with @fwang, it was decided to add an optional esbuildConfig setting to sst.json.

This PR adds that setting to sst.json and it is used in cdkhelpers.  It does not affect or override what is used for building the nodejs functions.

A future PR can look at somehow merging esbuildConfig from sst.json with defaultFunctionProps if that is desired.