### PR TITLE
Queue: Append .fifo to queue name when fifo is true

### DIFF
--- a/packages/resources/src/Queue.ts
+++ b/packages/resources/src/Queue.ts
@@ -38,7 +38,7 @@ export class Queue extends cdk.Construct {
     if (cdk.Construct.isConstruct(sqsQueue)) {
       this.sqsQueue = sqsQueue as sqs.Queue;
     } else {
-      const sqsQueueProps = (sqsQueue || {}) as sqs.QueueProps;
+      const sqsQueueProps: sqs.QueueProps = sqsQueue || {};
 
       // If debugIncreaseTimeout is enabled (ie. sst start):
       // - Set visibilityTimeout to > 900s. This is because Lambda timeout is
@@ -57,8 +57,10 @@ export class Queue extends cdk.Construct {
         }
       }
 
+      const name =
+        root.logicalPrefixedName(id) + (sqsQueueProps.fifo ? ".fifo" : "");
       this.sqsQueue = new sqs.Queue(this, "Queue", {
-        queueName: root.logicalPrefixedName(id),
+        queueName: name,
         ...sqsQueueProps,
         ...(debugOverrideProps || {}),
       });

--- a/packages/resources/test/Queue.test.ts
+++ b/packages/resources/test/Queue.test.ts
@@ -27,14 +27,14 @@ const queueDefaultPolicy = {
 // Test Constructor
 /////////////////////////////
 
-test("constructor-undefined", async () => {
+test("sqsQueue: is undefined", async () => {
   const stack = new Stack(new App(), "stack");
   new Queue(stack, "Queue");
   expect(stack).toCountResources("AWS::SQS::Queue", 1);
   expect(stack).toCountResources("AWS::Lambda::EventSourceMapping", 0);
 });
 
-test("sqsQueue-is-sqsQueueConstruct", async () => {
+test("sqsQueue: is sqs.Queue construct", async () => {
   const stack = new Stack(new App(), "stack");
   const queue = new sqs.Queue(stack, "Q", {
     queueName: "my-queue",
@@ -57,7 +57,7 @@ test("sqsQueue-is-sqsQueueConstruct", async () => {
   });
 });
 
-test("sqsQueue-is-sqsQueueProps", async () => {
+test("sqsQueue: is QueueProps", async () => {
   const stack = new Stack(new App(), "stack");
   new Queue(stack, "Queue", {
     consumer: "test/lambda.handler",
@@ -78,7 +78,32 @@ test("sqsQueue-is-sqsQueueProps", async () => {
   expect(stack).toCountResources("AWS::Lambda::EventSourceMapping", 1);
 });
 
-test("consumer-string", async () => {
+test("sqsQueue: fifo does not override custom name", async () => {
+  const stack = new Stack(new App(), "stack");
+  expect(
+    () =>
+      new Queue(stack, "Queue", {
+        sqsQueue: {
+          queueName: "myqueue",
+          fifo: true,
+        },
+      })
+  ).toThrow(/FIFO queue names must end in '.fifo/);
+});
+
+test("sqsQueue: fifo appends to name", async () => {
+  const stack = new Stack(new App(), "stack");
+  new Queue(stack, "Queue", {
+    sqsQueue: {
+      fifo: true,
+    },
+  });
+  expect(stack).toHaveResource("AWS::SQS::Queue", {
+    QueueName: "dev-my-app-Queue.fifo",
+  });
+});
+
+test("consumer: is string", async () => {
   const stack = new Stack(new App(), "stack");
   new Queue(stack, "Queue", {
     consumer: "test/lambda.handler",
@@ -93,7 +118,7 @@ test("consumer-string", async () => {
   });
 });
 
-test("consumer-Function", async () => {
+test("consumer: is Function", async () => {
   const stack = new Stack(new App(), "stack");
   const f = new Function(stack, "Function", { handler: "test/lambda.handler" });
   new Queue(stack, "Queue", {
@@ -107,7 +132,7 @@ test("consumer-Function", async () => {
   });
 });
 
-test("consumer-FunctionProps", async () => {
+test("consumer: is FunctionProps", async () => {
   const stack = new Stack(new App(), "stack");
   new Queue(stack, "Queue", {
     consumer: { handler: "test/lambda.handler" },
@@ -120,7 +145,7 @@ test("consumer-FunctionProps", async () => {
   });
 });
 
-test("consumer-props", async () => {
+test("consumer: is props", async () => {
   const stack = new Stack(new App(), "stack");
   new Queue(stack, "Queue", {
     consumer: {
@@ -141,7 +166,7 @@ test("consumer-props", async () => {
   });
 });
 
-test("consumer-undefined", async () => {
+test("consumer: is undefined", async () => {
   const stack = new Stack(new App(), "stack");
   new Queue(stack, "Queue", {});
   expect(stack).toCountResources("AWS::SQS::Queue", 1);

--- a/packages/resources/test/Queue.test.ts
+++ b/packages/resources/test/Queue.test.ts
@@ -148,7 +148,20 @@ test("consumer-undefined", async () => {
   expect(stack).toCountResources("AWS::Lambda::EventSourceMapping", 0);
 });
 
-test.only("fifo appends to name", async () => {
+test("fifo does not override custom name", async () => {
+  const stack = new Stack(new App(), "stack");
+  expect(
+    () =>
+      new Queue(stack, "Queue", {
+        sqsQueue: {
+          queueName: "myqueue",
+          fifo: true,
+        },
+      })
+  ).toThrow(/FIFO queue names must end in '.fifo/);
+});
+
+test("fifo appends to name", async () => {
   const stack = new Stack(new App(), "stack");
   new Queue(stack, "Queue", {
     sqsQueue: {

--- a/packages/resources/test/Queue.test.ts
+++ b/packages/resources/test/Queue.test.ts
@@ -148,6 +148,18 @@ test("consumer-undefined", async () => {
   expect(stack).toCountResources("AWS::Lambda::EventSourceMapping", 0);
 });
 
+test.only("fifo appends to name", async () => {
+  const stack = new Stack(new App(), "stack");
+  new Queue(stack, "Queue", {
+    sqsQueue: {
+      fifo: true,
+    },
+  });
+  expect(stack).toHaveResource("AWS::SQS::Queue", {
+    QueueName: "dev-my-app-Queue.fifo",
+  });
+});
+
 /////////////////////////////
 // Test Constructor for Local Debug
 /////////////////////////////


### PR DESCRIPTION
I decided not to override a name that the user configured so that nothing unexpected happens

fixes #639 