### PR TITLE
Fix for copyFiles because outCode does not reliably return relative path

### DIFF
--- a/packages/resources/src/Function.ts
+++ b/packages/resources/src/Function.ts
@@ -293,11 +293,7 @@ export class Function extends lambda.Function {
         outCode = ret.outCode;
         outHandler = ret.outHandler;
       }
-      Function.copyFiles(
-        bundle,
-        srcPath,
-        path.join(process.cwd(), outCode.path)
-      );
+      Function.copyFiles(bundle, srcPath, outCode.path);
       super(scope, id, {
         ...props,
         runtime,


### PR DESCRIPTION
The Go build returns an absolute path while the Node build returns a relative one

This structure could use a bit of refactoring since it wasn't intended to support multiple language from the beginning. Will follow up with that