### PR TITLE
StaticSite: Add support for external domains

### DIFF
--- a/packages/resources/src/StaticSite.ts
+++ b/packages/resources/src/StaticSite.ts
@@ -410,26 +410,26 @@ export class StaticSite extends cdk.Construct {
 
     const cfDistributionProps = cfDistribution || {};
 
-    // Validate input
-    if (cfDistributionProps.certificate) {
-      throw new Error(
-        `Do not configure the "cfDistribution.certificate". Use the "customDomain" to configure the StaticSite domain certificate.`
-      );
-    }
-    if (cfDistributionProps.domainNames) {
-      throw new Error(
-        `Do not configure the "cfDistribution.domainNames". Use the "customDomain" to configure the StaticSite domain.`
-      );
-    }
-
-    // Build domainNames
     const domainNames = [];
-    if (!customDomain) {
-      // no domain
-    } else if (typeof customDomain === "string") {
-      domainNames.push(customDomain);
-    } else {
-      domainNames.push(customDomain.domainName);
+
+    if (customDomain) {
+      // Validate input
+      if (cfDistributionProps.certificate) {
+        throw new Error(
+          `Do not configure the "cfDistribution.certificate" when using "customDomain". Use the "customDomain" to configure the StaticSite domain certificate.`
+        );
+      }
+      if (cfDistributionProps.domainNames) {
+        throw new Error(
+          `Do not configure the "cfDistribution.domainNames" when using "customDomain". Use the "customDomain" to configure the StaticSite domain.`
+        );
+      }
+      // Build domainNames
+      if (typeof customDomain === "string") {
+        domainNames.push(customDomain);
+      } else {
+        domainNames.push(customDomain.domainName);
+      }
     }
 
     // Build errorResponses
@@ -455,10 +455,11 @@ export class StaticSite extends cdk.Construct {
       // these values can be overwritten by cfDistributionProps
       defaultRootObject: indexPage,
       errorResponses,
-      ...cfDistributionProps,
-      // these values can NOT be overwritten by cfDistributionProps
+      // if customDomain these values should NOT be overwritten by cfDistributionProps
       domainNames,
       certificate: this.acmCertificate,
+      ...cfDistributionProps,
+      // these values can NOT be overwritten by cfDistributionProps
       defaultBehavior: {
         origin: new cfOrigins.S3Origin(this.s3Bucket, {
           originPath: this.deployId,

--- a/www/docs/constructs/ReactStaticSite.md
+++ b/www/docs/constructs/ReactStaticSite.md
@@ -127,9 +127,9 @@ There are a couple of things happening behind the scenes here:
 
 ### Configuring custom domains
 
-You can also configure custom domains for your React app. SST currently supports domains that are configured using [Route 53](https://aws.amazon.com/route53/). If your domains are hosted elsewhere, you can [follow this guide to migrate them to Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
+You can also configure custom domains for your React app.
 
-Using the basic config.
+Using the basic config for a domain hosted on [Route 53](https://aws.amazon.com/route53/).
 
 ```js {3}
 new ReactStaticSite(this, "ReactSite", {

--- a/www/docs/constructs/StaticSite.md
+++ b/www/docs/constructs/StaticSite.md
@@ -182,9 +182,9 @@ There are a couple of things happening behind the scenes here:
 ```
 :::
 
-### Configuring custom domains
+### Configuring custom domains hosted on Route 53
 
-You can also configure the website with a custom domain. SST currently supports domains that are configured using [Route 53](https://aws.amazon.com/route53/). If your domains are hosted elsewhere, you can [follow this guide to migrate them to Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
+You can configure the website with a custom domain hosted on [Route 53](https://aws.amazon.com/route53/). To migrate externally hosted domains to Route 53 [follow this guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
 
 #### Using the basic config
 
@@ -273,9 +273,27 @@ new StaticSite(this, "Site", {
 });
 ```
 
+### Configuring domains hosted externally
+
+For externally hosted domains, configure the internally created CDK `Distribution`
+
+```js {5-8}
+import { Certificate } from "@aws-cdk/aws-certificatemanager";
+
+new StaticSite(this, "Site", {
+  path: "path/to/src",
+  cfDistribution: {
+    domainNames: ["www.domain.com"],
+    certificate: Certificate.fromCertificateArn(this, "MyCert", certArn),
+  },
+});
+```
+
+Note that the certificate needs be created in the `us-east-1`(N. Virginia) region as required by AWS CloudFront, and validated. After the `Distribution` has been created, create a CNAME DNS record for your domain name with the `Distribution's` URL as the value.
+
 ### Configure caching
 
-Configure the Cache Control settings based on differnt file types.
+Configure the Cache Control settings based on different file types.
 
 ```js {6-17}
 new StaticSite(this, "Site", {
@@ -662,7 +680,7 @@ A string that is to be replaced by the `replace` prop. Note that this isn't a re
 
 _Type_ : `string`
 
-The string that replaces the substring specified by the specified `search` prop. 
+The string that replaces the substring specified by the specified `search` prop.
 
 ## StaticSiteCdkDistributionProps
 


### PR DESCRIPTION
Enhancement., As discussed on Slack. I've created a new test case and updated two existing test cases. I've tested this e2e for my own domain.

For external domains omit customDomain, and include:

```
cfDistribution: {
  domainNames: ["domain.com"],
  certificate: Certificate.fromCertificateArn(this, "MyCert", certArn)
}
```
Then set external domain's CNAME record to the cloudfront distribution's URL.

Documentation to follow in a subsequent PR.