### PR TITLE
StaticSite: Add support for external domains

### DIFF
--- a/packages/resources/src/StaticSite.ts
+++ b/packages/resources/src/StaticSite.ts
@@ -459,26 +459,26 @@ export class StaticSite extends cdk.Construct {
 
     const cfDistributionProps = cfDistribution || {};
 
-    const domainNames = [];
+    // Validate input
+    if (cfDistributionProps.certificate) {
+      throw new Error(
+        `Do not configure the "cfDistribution.certificate" when using "customDomain". Use the "customDomain" to configure the StaticSite domain certificate.`
+      );
+    }
+    if (cfDistributionProps.domainNames) {
+      throw new Error(
+        `Do not configure the "cfDistribution.domainNames" when using "customDomain". Use the "customDomain" to configure the StaticSite domain.`
+      );
+    }
 
-    if (customDomain) {
-      // Validate input
-      if (cfDistributionProps.certificate) {
-        throw new Error(
-          `Do not configure the "cfDistribution.certificate" when using "customDomain". Use the "customDomain" to configure the StaticSite domain certificate.`
-        );
-      }
-      if (cfDistributionProps.domainNames) {
-        throw new Error(
-          `Do not configure the "cfDistribution.domainNames" when using "customDomain". Use the "customDomain" to configure the StaticSite domain.`
-        );
-      }
-      // Build domainNames
-      if (typeof customDomain === "string") {
-        domainNames.push(customDomain);
-      } else {
-        domainNames.push(customDomain.domainName);
-      }
+    // Build domainNames
+    const domainNames = [];
+    if (!customDomain) {
+      // no domain
+    } else if (typeof customDomain === "string") {
+      domainNames.push(customDomain);
+    } else {
+      domainNames.push(customDomain.domainName);
     }
 
     // Build errorResponses
@@ -504,11 +504,10 @@ export class StaticSite extends cdk.Construct {
       // these values can be overwritten by cfDistributionProps
       defaultRootObject: indexPage,
       errorResponses,
-      // if customDomain these values should NOT be overwritten by cfDistributionProps
-      domainNames,
-      certificate: this.acmCertificate,
       ...cfDistributionProps,
       // these values can NOT be overwritten by cfDistributionProps
+      domainNames,
+      certificate: this.acmCertificate,
       defaultBehavior: {
         origin: new cfOrigins.S3Origin(this.s3Bucket, {
           originPath: this.deployId,

--- a/packages/resources/src/StaticSite.ts
+++ b/packages/resources/src/StaticSite.ts
@@ -410,26 +410,26 @@ export class StaticSite extends cdk.Construct {
 
     const cfDistributionProps = cfDistribution || {};
 
-    // Validate input
-    if (cfDistributionProps.certificate) {
-      throw new Error(
-        `Do not configure the "cfDistribution.certificate". Use the "customDomain" to configure the StaticSite domain certificate.`
-      );
-    }
-    if (cfDistributionProps.domainNames) {
-      throw new Error(
-        `Do not configure the "cfDistribution.domainNames". Use the "customDomain" to configure the StaticSite domain.`
-      );
-    }
-
-    // Build domainNames
     const domainNames = [];
-    if (!customDomain) {
-      // no domain
-    } else if (typeof customDomain === "string") {
-      domainNames.push(customDomain);
-    } else {
-      domainNames.push(customDomain.domainName);
+
+    if (customDomain) {
+      // Validate input
+      if (cfDistributionProps.certificate) {
+        throw new Error(
+          `Do not configure the "cfDistribution.certificate" when using "customDomain". Use the "customDomain" to configure the StaticSite domain certificate.`
+        );
+      }
+      if (cfDistributionProps.domainNames) {
+        throw new Error(
+          `Do not configure the "cfDistribution.domainNames" when using "customDomain". Use the "customDomain" to configure the StaticSite domain.`
+        );
+      }
+      // Build domainNames
+      if (typeof customDomain === "string") {
+        domainNames.push(customDomain);
+      } else {
+        domainNames.push(customDomain.domainName);
+      }
     }
 
     // Build errorResponses
@@ -455,10 +455,11 @@ export class StaticSite extends cdk.Construct {
       // these values can be overwritten by cfDistributionProps
       defaultRootObject: indexPage,
       errorResponses,
-      ...cfDistributionProps,
-      // these values can NOT be overwritten by cfDistributionProps
+      // if customDomain these values should NOT be overwritten by cfDistributionProps
       domainNames,
       certificate: this.acmCertificate,
+      ...cfDistributionProps,
+      // these values can NOT be overwritten by cfDistributionProps
       defaultBehavior: {
         origin: new cfOrigins.S3Origin(this.s3Bucket, {
           originPath: this.deployId,

--- a/packages/resources/src/StaticSite.ts
+++ b/packages/resources/src/StaticSite.ts
@@ -42,6 +42,7 @@ export interface StaticSiteDomainProps {
   readonly domainAlias?: string;
   readonly hostedZone?: string | route53.IHostedZone;
   readonly certificate?: acm.ICertificate;
+  readonly isExternalDomain?: boolean;
 }
 
 export interface StaticSiteFileOption {
@@ -130,6 +131,9 @@ export class StaticSite extends cdk.Construct {
 
     this.props = props;
 
+    // Validate input
+    this.validateCustomDomainSettings();
+
     // Build website
     this.assets = this.buildApp(fileSizeLimit, buildDir, isSstStart, skipBuild);
     const assetsHash = crypto
@@ -178,6 +182,36 @@ export class StaticSite extends cdk.Construct {
 
   public get distributionDomain(): string {
     return this.cfDistribution.distributionDomainName;
+  }
+
+  protected validateCustomDomainSettings() {
+    const { customDomain } = this.props;
+
+    if (!customDomain) {
+      return;
+    }
+
+    if (typeof customDomain === "string") {
+      return;
+    }
+
+    if (customDomain.isExternalDomain === true) {
+      if (!customDomain.certificate) {
+        throw new Error(
+          `A valid certificate is required when "isExternalDomain" is set to "true".`
+        );
+      }
+      if (customDomain.domainAlias) {
+        throw new Error(
+          `Domain alias is only supported for domains hosted on Amazon Route 53. Do not set the "customDomain.domainAlias" when "isExternalDomain" is enabled.`
+        );
+      }
+      if (customDomain.hostedZone) {
+        throw new Error(
+          `Hosted zones can only be configured for domains hosted on Amazon Route 53. Do not set the "customDomain.hostedZone" when "isExternalDomain" is enabled.`
+        );
+      }
+    }
   }
 
   private createS3Bucket(): s3.Bucket {
@@ -348,6 +382,7 @@ export class StaticSite extends cdk.Construct {
   protected lookupHostedZone(): route53.IHostedZone | undefined {
     const { customDomain } = this.props;
 
+    // Skip if customDomain is not configured
     if (!customDomain) {
       return;
     }
@@ -365,6 +400,11 @@ export class StaticSite extends cdk.Construct {
         domainName: customDomain.hostedZone,
       });
     } else if (typeof customDomain.domainName === "string") {
+      // Skip if domain is not a Route53 domain
+      if (customDomain.isExternalDomain === true) {
+        return;
+      }
+
       hostedZone = route53.HostedZone.fromLookup(this, "HostedZone", {
         domainName: customDomain.domainName,
       });
@@ -378,26 +418,35 @@ export class StaticSite extends cdk.Construct {
   private createCertificate(): acm.ICertificate | undefined {
     const { customDomain } = this.props;
 
-    if (!customDomain || !this.hostedZone) {
+    if (!customDomain) {
       return;
     }
 
     let acmCertificate;
 
-    if (typeof customDomain === "string") {
-      acmCertificate = new acm.DnsValidatedCertificate(this, "Certificate", {
-        domainName: customDomain,
-        hostedZone: this.hostedZone,
-        region: "us-east-1",
-      });
-    } else if (customDomain.certificate) {
-      acmCertificate = customDomain.certificate;
-    } else {
-      acmCertificate = new acm.DnsValidatedCertificate(this, "Certificate", {
-        domainName: customDomain.domainName,
-        hostedZone: this.hostedZone,
-        region: "us-east-1",
-      });
+    // HostedZone is set for Route 53 domains
+    if (this.hostedZone) {
+      if (typeof customDomain === "string") {
+        acmCertificate = new acm.DnsValidatedCertificate(this, "Certificate", {
+          domainName: customDomain,
+          hostedZone: this.hostedZone,
+          region: "us-east-1",
+        });
+      } else if (customDomain.certificate) {
+        acmCertificate = customDomain.certificate;
+      } else {
+        acmCertificate = new acm.DnsValidatedCertificate(this, "Certificate", {
+          domainName: customDomain.domainName,
+          hostedZone: this.hostedZone,
+          region: "us-east-1",
+        });
+      }
+    }
+    // HostedZone is NOT set for non-Route 53 domains
+    else {
+      if (typeof customDomain !== "string") {
+        acmCertificate = customDomain.certificate;
+      }
     }
 
     return acmCertificate;
@@ -410,26 +459,26 @@ export class StaticSite extends cdk.Construct {
 
     const cfDistributionProps = cfDistribution || {};
 
-    const domainNames = [];
+    // Validate input
+    if (cfDistributionProps.certificate) {
+      throw new Error(
+        `Do not configure the "cfDistribution.certificate". Use the "customDomain" to configure the StaticSite domain certificate.`
+      );
+    }
+    if (cfDistributionProps.domainNames) {
+      throw new Error(
+        `Do not configure the "cfDistribution.domainNames". Use the "customDomain" to configure the StaticSite domain.`
+      );
+    }
 
-    if (customDomain) {
-      // Validate input
-      if (cfDistributionProps.certificate) {
-        throw new Error(
-          `Do not configure the "cfDistribution.certificate" when using "customDomain". Use the "customDomain" to configure the StaticSite domain certificate.`
-        );
-      }
-      if (cfDistributionProps.domainNames) {
-        throw new Error(
-          `Do not configure the "cfDistribution.domainNames" when using "customDomain". Use the "customDomain" to configure the StaticSite domain.`
-        );
-      }
-      // Build domainNames
-      if (typeof customDomain === "string") {
-        domainNames.push(customDomain);
-      } else {
-        domainNames.push(customDomain.domainName);
-      }
+    // Build domainNames
+    const domainNames = [];
+    if (!customDomain) {
+      // no domain
+    } else if (typeof customDomain === "string") {
+      domainNames.push(customDomain);
+    } else {
+      domainNames.push(customDomain.domainName);
     }
 
     // Build errorResponses
@@ -455,11 +504,10 @@ export class StaticSite extends cdk.Construct {
       // these values can be overwritten by cfDistributionProps
       defaultRootObject: indexPage,
       errorResponses,
-      // if customDomain these values should NOT be overwritten by cfDistributionProps
-      domainNames,
-      certificate: this.acmCertificate,
       ...cfDistributionProps,
       // these values can NOT be overwritten by cfDistributionProps
+      domainNames,
+      certificate: this.acmCertificate,
       defaultBehavior: {
         origin: new cfOrigins.S3Origin(this.s3Bucket, {
           originPath: this.deployId,

--- a/packages/resources/src/StaticSite.ts
+++ b/packages/resources/src/StaticSite.ts
@@ -459,26 +459,26 @@ export class StaticSite extends cdk.Construct {
 
     const cfDistributionProps = cfDistribution || {};
 
-    // Validate input
-    if (cfDistributionProps.certificate) {
-      throw new Error(
-        `Do not configure the "cfDistribution.certificate". Use the "customDomain" to configure the StaticSite domain certificate.`
-      );
-    }
-    if (cfDistributionProps.domainNames) {
-      throw new Error(
-        `Do not configure the "cfDistribution.domainNames". Use the "customDomain" to configure the StaticSite domain.`
-      );
-    }
-
-    // Build domainNames
     const domainNames = [];
-    if (!customDomain) {
-      // no domain
-    } else if (typeof customDomain === "string") {
-      domainNames.push(customDomain);
-    } else {
-      domainNames.push(customDomain.domainName);
+
+    if (customDomain) {
+      // Validate input
+      if (cfDistributionProps.certificate) {
+        throw new Error(
+          `Do not configure the "cfDistribution.certificate" when using "customDomain". Use the "customDomain" to configure the StaticSite domain certificate.`
+        );
+      }
+      if (cfDistributionProps.domainNames) {
+        throw new Error(
+          `Do not configure the "cfDistribution.domainNames" when using "customDomain". Use the "customDomain" to configure the StaticSite domain.`
+        );
+      }
+      // Build domainNames
+      if (typeof customDomain === "string") {
+        domainNames.push(customDomain);
+      } else {
+        domainNames.push(customDomain.domainName);
+      }
     }
 
     // Build errorResponses
@@ -504,10 +504,11 @@ export class StaticSite extends cdk.Construct {
       // these values can be overwritten by cfDistributionProps
       defaultRootObject: indexPage,
       errorResponses,
-      ...cfDistributionProps,
-      // these values can NOT be overwritten by cfDistributionProps
+      // if customDomain these values should NOT be overwritten by cfDistributionProps
       domainNames,
       certificate: this.acmCertificate,
+      ...cfDistributionProps,
+      // these values can NOT be overwritten by cfDistributionProps
       defaultBehavior: {
         origin: new cfOrigins.S3Origin(this.s3Bucket, {
           originPath: this.deployId,

--- a/packages/resources/src/StaticSite.ts
+++ b/packages/resources/src/StaticSite.ts
@@ -462,12 +462,12 @@ export class StaticSite extends cdk.Construct {
     // Validate input
     if (cfDistributionProps.certificate) {
       throw new Error(
-        `Do not configure the "cfDistribution.certificate" when using "customDomain". Use the "customDomain" to configure the StaticSite domain certificate.`
+        `Do not configure the "cfDistribution.certificate". Use the "customDomain" to configure the StaticSite domain certificate.`
       );
     }
     if (cfDistributionProps.domainNames) {
       throw new Error(
-        `Do not configure the "cfDistribution.domainNames" when using "customDomain". Use the "customDomain" to configure the StaticSite domain.`
+        `Do not configure the "cfDistribution.domainNames". Use the "customDomain" to configure the StaticSite domain.`
       );
     }
 

--- a/packages/resources/test/StaticSite.test.ts
+++ b/packages/resources/test/StaticSite.test.ts
@@ -867,12 +867,11 @@ test("constructor: cfDistribution defaultBehavior override", async () => {
   );
 });
 
-test("constructor: cfDistribution certificate conflict with customDomain", async () => {
+test("constructor: cfDistribution certificate conflict", async () => {
   const stack = new Stack(new App(), "stack");
   expect(() => {
     new StaticSite(stack, "Site", {
       path: "test/site",
-      customDomain: "domain.com",
       cfDistribution: {
         certificate: new acm.Certificate(stack, "Cert", {
           domainName: "domain.com",
@@ -884,12 +883,11 @@ test("constructor: cfDistribution certificate conflict with customDomain", async
   );
 });
 
-test("constructor: cfDistribution domainNames conflict with customDomain", async () => {
+test("constructor: cfDistribution domainNames conflict", async () => {
   const stack = new Stack(new App(), "stack");
   expect(() => {
     new StaticSite(stack, "Site", {
       path: "test/site",
-      customDomain: "domain.com",
       cfDistribution: {
         domainNames: ["domain.com"],
       },

--- a/packages/resources/test/StaticSite.test.ts
+++ b/packages/resources/test/StaticSite.test.ts
@@ -867,30 +867,36 @@ test("constructor: cfDistribution defaultBehavior override", async () => {
   );
 });
 
-test("constructor: cfDistribution certificate", async () => {
+test("constructor: cfDistribution certificate conflict with customDomain", async () => {
   const stack = new Stack(new App(), "stack");
   expect(() => {
     new StaticSite(stack, "Site", {
       path: "test/site",
+      customDomain: "domain.com",
       cfDistribution: {
         certificate: new acm.Certificate(stack, "Cert", {
           domainName: "domain.com",
         }),
       },
     });
-  }).toThrow(/Do not configure the "cfDistribution.certificate"./);
+  }).toThrow(
+    /Do not configure the "cfDistribution.certificate" when using "customDomain"./
+  );
 });
 
-test("constructor: cfDistribution domainNames", async () => {
+test("constructor: cfDistribution domainNames conflict with customDomain", async () => {
   const stack = new Stack(new App(), "stack");
   expect(() => {
     new StaticSite(stack, "Site", {
       path: "test/site",
+      customDomain: "domain.com",
       cfDistribution: {
         domainNames: ["domain.com"],
       },
     });
-  }).toThrow(/Do not configure the "cfDistribution.domainNames"./);
+  }).toThrow(
+    /Do not configure the "cfDistribution.domainNames" when using "customDomain"./
+  );
 });
 
 test("constructor: environment generates placeholders", async () => {

--- a/packages/resources/test/StaticSite.test.ts
+++ b/packages/resources/test/StaticSite.test.ts
@@ -114,6 +114,13 @@ test("constructor: with domain", async () => {
   expect(site.acmCertificate).toBeDefined();
   expectCdk(stack).to(countResources("AWS::S3::Bucket", 1));
   expectCdk(stack).to(countResources("AWS::CloudFront::Distribution", 1));
+  expectCdk(stack).to(
+    haveResource("AWS::CloudFront::Distribution", {
+      DistributionConfig: objectLike({
+        Aliases: ["domain.com"],
+      }),
+    })
+  );
   expectCdk(stack).to(countResources("AWS::Route53::RecordSet", 1));
   expectCdk(stack).to(
     haveResource("AWS::Route53::RecordSet", {

--- a/packages/resources/test/StaticSite.test.ts
+++ b/packages/resources/test/StaticSite.test.ts
@@ -879,7 +879,7 @@ test("constructor: cfDistribution certificate conflict", async () => {
       },
     });
   }).toThrow(
-    /Do not configure the "cfDistribution.certificate" when using "customDomain"./
+    /Do not configure the "cfDistribution.certificate"/
   );
 });
 
@@ -893,7 +893,7 @@ test("constructor: cfDistribution domainNames conflict", async () => {
       },
     });
   }).toThrow(
-    /Do not configure the "cfDistribution.domainNames" when using "customDomain"./
+    /Do not configure the "cfDistribution.domainNames"/
   );
 });
 

--- a/www/docs/constructs/ReactStaticSite.md
+++ b/www/docs/constructs/ReactStaticSite.md
@@ -127,7 +127,7 @@ There are a couple of things happening behind the scenes here:
 
 ### Configuring custom domains
 
-You can also configure custom domains for your React app.
+You can also configure custom domains for your React app. SST supports domains that are shoted either on [Route 53](https://aws.amazon.com/route53/) or externally.
 
 Using the basic config for a domain hosted on [Route 53](https://aws.amazon.com/route53/).
 

--- a/www/docs/constructs/ReactStaticSite.md
+++ b/www/docs/constructs/ReactStaticSite.md
@@ -127,9 +127,9 @@ There are a couple of things happening behind the scenes here:
 
 ### Configuring custom domains
 
-You can also configure custom domains for your React app. SST currently supports domains that are configured using [Route 53](https://aws.amazon.com/route53/). If your domains are hosted elsewhere, you can [follow this guide to migrate them to Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
+You can also configure custom domains for your React app.
 
-Using the basic config.
+Using the basic config for a domain hosted on [Route 53](https://aws.amazon.com/route53/).
 
 ```js {3}
 new ReactStaticSite(this, "ReactSite", {

--- a/www/docs/constructs/StaticSite.md
+++ b/www/docs/constructs/StaticSite.md
@@ -182,9 +182,9 @@ There are a couple of things happening behind the scenes here:
 
 :::
 
-### Configuring custom domains
+### Configuring custom domains hosted on Route 53
 
-You can also configure the website with a custom domain. SST currently supports domains that are configured using [Route 53](https://aws.amazon.com/route53/). If your domains are hosted elsewhere, you can [follow this guide to migrate them to Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
+You can configure the website with a custom domain hosted on [Route 53](https://aws.amazon.com/route53/). To migrate externally hosted domains to Route 53 [follow this guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
 
 #### Using the basic config
 
@@ -274,9 +274,27 @@ new StaticSite(this, "Site", {
 });
 ```
 
+### Configuring domains hosted externally
+
+For externally hosted domains, configure the internally created CDK `Distribution`
+
+```js {5-8}
+import { Certificate } from "@aws-cdk/aws-certificatemanager";
+
+new StaticSite(this, "Site", {
+  path: "path/to/src",
+  cfDistribution: {
+    domainNames: ["www.domain.com"],
+    certificate: Certificate.fromCertificateArn(this, "MyCert", certArn),
+  },
+});
+```
+
+Note that the certificate needs be created in the `us-east-1`(N. Virginia) region as required by AWS CloudFront, and validated. After the `Distribution` has been created, create a CNAME DNS record for your domain name with the `Distribution's` URL as the value.
+
 ### Configure caching
 
-Configure the Cache Control settings based on differnt file types.
+Configure the Cache Control settings based on different file types.
 
 ```js {6-17}
 new StaticSite(this, "Site", {

--- a/www/docs/constructs/StaticSite.md
+++ b/www/docs/constructs/StaticSite.md
@@ -182,7 +182,7 @@ There are a couple of things happening behind the scenes here:
 
 :::
 
-### Configuring custom domains
+### Configuring custom domains hosted on Route 53
 
 You can configure the website with a custom domain hosted either on [Route 53](https://aws.amazon.com/route53/) or [externally](#configuring-externally-hosted-domain).
 
@@ -291,7 +291,7 @@ new StaticSite(this, "Site", {
 
 Note that the certificate needs be created in the `us-east-1`(N. Virginia) region as required by AWS CloudFront, and validated. After the `Distribution` has been created, create a CNAME DNS record for your domain name with the `Distribution's` URL as the value. Here are more details on [configuring SSL Certificate on externally hosted domains](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html).
 
-Note that you can also migrate externally hosted domains to Route 53 by [following this guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
+Also note that you can also migrate externally hosted domains to Route 53 by [following this guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
 
 ### Configure caching
 

--- a/www/docs/constructs/StaticSite.md
+++ b/www/docs/constructs/StaticSite.md
@@ -182,11 +182,11 @@ There are a couple of things happening behind the scenes here:
 
 :::
 
-### Configuring custom domains hosted on Route 53
+### Configuring custom domains
 
-You can configure the website with a custom domain hosted on [Route 53](https://aws.amazon.com/route53/). To migrate externally hosted domains to Route 53 [follow this guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
+You can configure the website with a custom domain hosted either on [Route 53](https://aws.amazon.com/route53/) or [externally](#configuring-externally-hosted-domain).
 
-#### Using the basic config
+#### Using the basic config (Route 53 domains)
 
 ```js {3}
 new StaticSite(this, "Site", {
@@ -195,7 +195,7 @@ new StaticSite(this, "Site", {
 });
 ```
 
-#### Redirect www to non-www
+#### Redirect www to non-www (Route 53 domains)
 
 ```js {3-6}
 new StaticSite(this, "Site", {
@@ -207,7 +207,7 @@ new StaticSite(this, "Site", {
 });
 ```
 
-#### Configuring domains across stages
+#### Configuring domains across stages (Route 53 domains)
 
 ```js {7-10}
 export default class MyStack extends Stack {
@@ -226,7 +226,7 @@ export default class MyStack extends Stack {
 }
 ```
 
-#### Using the full config
+#### Using the full config (Route 53 domains)
 
 ```js {3-7}
 new StaticSite(this, "Site", {
@@ -239,7 +239,7 @@ new StaticSite(this, "Site", {
 });
 ```
 
-#### Importing an existing certificate
+#### Importing an existing certificate (Route 53 domains)
 
 ```js {7}
 import { Certificate } from "@aws-cdk/aws-certificatemanager";
@@ -255,7 +255,7 @@ new StaticSite(this, "Site", {
 
 Note that, the certificate needs be created in the `us-east-1`(N. Virginia) region as required by AWS CloudFront.
 
-#### Specifying a hosted zone
+#### Specifying a hosted zone (Route 53 domains)
 
 If you have multiple hosted zones for a given domain, you can choose the one you want to use to configure the domain.
 
@@ -274,23 +274,24 @@ new StaticSite(this, "Site", {
 });
 ```
 
-### Configuring domains hosted externally
-
-For externally hosted domains, configure the internally created CDK `Distribution`
+#### Configuring externally hosted domain
 
 ```js {5-8}
 import { Certificate } from "@aws-cdk/aws-certificatemanager";
 
 new StaticSite(this, "Site", {
   path: "path/to/src",
-  cfDistribution: {
-    domainNames: ["www.domain.com"],
+  customDomain: {
+    isExternalDomain: true,
+    domainName: "domain.com",
     certificate: Certificate.fromCertificateArn(this, "MyCert", certArn),
   },
 });
 ```
 
-Note that the certificate needs be created in the `us-east-1`(N. Virginia) region as required by AWS CloudFront, and validated. After the `Distribution` has been created, create a CNAME DNS record for your domain name with the `Distribution's` URL as the value.
+Note that the certificate needs be created in the `us-east-1`(N. Virginia) region as required by AWS CloudFront, and validated. After the `Distribution` has been created, create a CNAME DNS record for your domain name with the `Distribution's` URL as the value. Here are more details on [configuring SSL Certificate on externally hosted domains](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html).
+
+Note that you can also migrate externally hosted domains to Route 53 by [following this guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
 
 ### Configure caching
 
@@ -527,7 +528,9 @@ The directory with the content that will be uploaded to the S3 bucket. If a `bui
 
 _Type_ : `string | StaticSiteDomainProps`
 
-The customDomain for this website. SST currently supports domains that are configured using [Route 53](https://aws.amazon.com/route53/). If your domains are hosted elsewhere, you can [follow this guide to migrate them to Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
+The customDomain for this website. SST supports domains that are hosted either on [Route 53](https://aws.amazon.com/route53/) or externally.
+
+Note that you can also migrate externally hosted domains to Route 53 by [following this guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
 
 Takes either the domain as a string.
 
@@ -617,7 +620,7 @@ _Type_ : `string`
 
 The domain to be assigned to the website URL (ie. `domain.com`).
 
-Currently supports domains that are configured using [Route 53](https://aws.amazon.com/route53/).
+Supports domains that are hosted either on [Route 53](https://aws.amazon.com/route53/) or externally.
 
 ### domainAlias?
 
@@ -642,6 +645,12 @@ _Type_ : [`cdk.aws-certificatemanager.ICertificate`](https://docs.aws.amazon.com
 The certificate for the domain. By default, SST will create a certificate with the domain name from the `domainName` option. The certificate will be created in the `us-east-1`(N. Virginia) region as required by AWS CloudFront.
 
 Set this option if you have an existing certificate in the `us-east-1` region in AWS Certificate Manager you want to use.
+
+### isExternalDomain?
+
+_Type_ : `boolean`, _defaults to `false`_
+
+Set this option if the domain is not hosted on Amazon Route 53.
 
 ## StaticSiteFileOption
 


### PR DESCRIPTION
Enhancement.  As discussed on Slack. With documentation , a new test case,  and two test cases updated.  I've tested this e2e for my own hostname.

In brief, for external domains omit customDomain, and include:

```
cfDistribution: {
  domainNames: ["www.domain.com"],
  certificate: Certificate.fromCertificateArn(this, "MyCert", certArn)
}
```
Then set external domain's CNAME record to the cloudfront distribution's URL.