### PR TITLE
Function: Throw useful error when copyFiles target does not exist

### DIFF
--- a/packages/resources/src/Function.ts
+++ b/packages/resources/src/Function.ts
@@ -366,7 +366,7 @@ export class Function extends lambda.Function {
         throw new Error(
           `Tried to copy nonexistent file from "${path.resolve(
             fromPath
-          )}" - check copyFile entry "${from}"`
+          )}" - check copyFiles entry "${from}"`
         );
       const toPath = path.join(buildPath, to);
       fs.copySync(fromPath, toPath);

--- a/packages/resources/src/Function.ts
+++ b/packages/resources/src/Function.ts
@@ -362,6 +362,12 @@ export class Function extends lambda.Function {
 
     bundle.copyFiles.forEach(({ from, to }) => {
       const fromPath = path.join(srcPath, from);
+      if (!fs.existsSync(fromPath))
+        throw new Error(
+          `Tried to copy nonexistent file from "${path.resolve(
+            fromPath
+          )}" - check copyFile entry "${from}"`
+        );
       const toPath = path.join(buildPath, to);
       fs.copySync(fromPath, toPath);
     });

--- a/packages/resources/test/Function.test.ts
+++ b/packages/resources/test/Function.test.ts
@@ -194,6 +194,18 @@ test("copyFiles", async () => {
   });
 });
 
+test("copyFiles nonexistent", async () => {
+  const stack = new Stack(new App(), "stack");
+  expect(() => {
+    new Function(stack, "Function", {
+      handler: "test/lambda.handler",
+      bundle: {
+        copyFiles: [{ from: "test/fail.js", to: "test/fail.js" }],
+      },
+    });
+  }).toThrow(/Tried to copy nonexistent file/);
+});
+
 test("runtime-string", async () => {
   const stack = new Stack(new App(), "stack");
   new Function(stack, "Function", {


### PR DESCRIPTION
Fixes #543 