### PR TITLE
Making Windows compatible

### DIFF
--- a/packages/core/src/packager/packager.ts
+++ b/packages/core/src/packager/packager.ts
@@ -57,10 +57,11 @@ const Yarn = Implementation({
 
 type Manager = typeof NPM | typeof Yarn;
 
-export function getManager(dir: string): Manager {
-  const topPath = /^[a-z]+:\\$/gi;
-  
-  var isTopPath = topPath.test(dir);
+const WINDOWS_TOP_PATH = /^[a-z]+:\\$/gi;
+
+export function getManager(dir: string): Manager 
+{ 
+  const isTopPath = dir === "/" || WINDOWS_TOP_PATH.test(dir);
   
   const lock = path.join(dir, "yarn.lock");
   if (fs.existsSync(lock)) return Yarn;

--- a/packages/core/src/packager/packager.ts
+++ b/packages/core/src/packager/packager.ts
@@ -60,7 +60,8 @@ type Manager = typeof NPM | typeof Yarn;
 export function getManager(dir: string): Manager {
   const lock = path.join(dir, "yarn.lock");
   if (fs.existsSync(lock)) return Yarn;
-  if (path.resolve(dir, "..") === dir) {
+  const upDir = path.resolve(dir, "..")
+  if (upDir === dir) {
     return NPM;
   }
   return getManager(upDir);

--- a/packages/core/src/packager/packager.ts
+++ b/packages/core/src/packager/packager.ts
@@ -58,8 +58,12 @@ const Yarn = Implementation({
 type Manager = typeof NPM | typeof Yarn;
 
 export function getManager(dir: string): Manager {
+  const topPath = /^[a-z]+:\\$/gi;
+  
+  var isTopPath = topPath.test(dir);
+  
   const lock = path.join(dir, "yarn.lock");
   if (fs.existsSync(lock)) return Yarn;
-  if (dir === "/") return NPM;
+  if (dir === "/"  || isTopPath) return NPM;
   return getManager(path.resolve(dir, ".."));
 }

--- a/packages/core/src/packager/packager.ts
+++ b/packages/core/src/packager/packager.ts
@@ -65,6 +65,6 @@ export function getManager(dir: string): Manager
   
   const lock = path.join(dir, "yarn.lock");
   if (fs.existsSync(lock)) return Yarn;
-  if (dir === "/"  || isTopPath) return NPM;
+  if (isTopPath) return NPM;
   return getManager(path.resolve(dir, ".."));
 }

--- a/packages/core/src/packager/packager.ts
+++ b/packages/core/src/packager/packager.ts
@@ -60,12 +60,8 @@ type Manager = typeof NPM | typeof Yarn;
 export function getManager(dir: string): Manager {
   const lock = path.join(dir, "yarn.lock");
   if (fs.existsSync(lock)) return Yarn;
-
-  let upDir = path.resolve(dir, "..");
-
-  if (upDir === dir) {
+  if (path.resolve(dir, "..") === dir) {
     return NPM;
   }
-  
   return getManager(upDir);
 }

--- a/packages/core/src/packager/packager.ts
+++ b/packages/core/src/packager/packager.ts
@@ -57,14 +57,15 @@ const Yarn = Implementation({
 
 type Manager = typeof NPM | typeof Yarn;
 
-const WINDOWS_TOP_PATH = /^[a-z]+:\\$/gi;
-
-export function getManager(dir: string): Manager 
-{ 
-  const isTopPath = dir === "/" || WINDOWS_TOP_PATH.test(dir);
-  
+export function getManager(dir: string): Manager {
   const lock = path.join(dir, "yarn.lock");
   if (fs.existsSync(lock)) return Yarn;
-  if (isTopPath) return NPM;
-  return getManager(path.resolve(dir, ".."));
+
+  let upDir = path.resolve(dir, "..");
+
+  if (upDir === dir) {
+    return NPM;
+  }
+  
+  return getManager(upDir);
 }


### PR DESCRIPTION
Without this change, hitting the root drive (whatever letter) would case a RangeError: Maximum call stack size exceeded