### PR TITLE
Add ARN property to API stack

### DIFF
--- a/packages/resources/src/Api.ts
+++ b/packages/resources/src/Api.ts
@@ -7,6 +7,7 @@ import * as elb from "@aws-cdk/aws-elasticloadbalancingv2";
 import * as logs from "@aws-cdk/aws-logs";
 
 import { App } from "./App";
+import { Stack } from "./Stack";
 import { Function as Fn, FunctionProps, FunctionDefinition } from "./Function";
 import { Permissions } from "./util/permission";
 import * as apigV2Domain from "./util/apiGatewayV2Domain";
@@ -278,6 +279,11 @@ export class Api extends cdk.Construct {
 
   public get routes(): string[] {
     return Object.keys(this.routesData);
+  }
+
+  public get httpApiArn(): string {
+    const stack = Stack.of(this);
+    return `arn:${stack.partition}:apigateway:${stack.region}::/apis/${this.httpApi.apiId}`;
   }
 
   public addRoutes(

--- a/packages/resources/test/Api.test.ts
+++ b/packages/resources/test/Api.test.ts
@@ -1904,3 +1904,17 @@ test("attachPermissions-after-addRoutes", async () => {
     })
   );
 });
+
+test("arn property", async () => {
+  const stack = new Stack(new App(), "stack");
+  const api = new Api(stack, "Api", {});
+  expect(api.httpApiArn).toBeDefined();
+
+  const apiId = api.httpApi.apiId;
+  const region = Stack.of(api).region;
+  const partition = Stack.of(api).partition;
+
+  expect(api.httpApiArn).toContain(
+    `arn:${partition}:apigateway:${region}::/apis/${apiId}`
+  );
+});


### PR DESCRIPTION
This PR adds the public property `httpApiArn` to `sst.API` so that it can be referenced as needed.

Format is `arn:partition:apigateway:region::/apis/api-id`

Closes issue #805 

See Slack thread for more context:  https://serverless-stack.slack.com/archives/C01HQQVC8TH/p1631258358391400
