### PR TITLE
Correctly load .env.test variables when running tests.

### DIFF
--- a/packages/cli/scripts/test.js
+++ b/packages/cli/scripts/test.js
@@ -32,7 +32,9 @@ argv.push(
 );
 
 // Load environment variables from dotenv
-Util.Environment.load();
+Util.Environment.load({
+  searchPaths: [`.env.test`],
+});
 
 // This is a very dirty workaround for https://github.com/facebook/jest/issues/5913.
 // We're trying to resolve the environment ourselves because Jest does it incorrectly.


### PR DESCRIPTION
We lost the ability to load variables from .env.test on this commit: https://github.com/serverless-stack/serverless-stack/commit/7976a797776478ea8a1049086d474e3f61e4d010

This pull request restores the ability to load .env.test variables.