### PR TITLE
Ensure esbuild config is deep copied

### DIFF
--- a/packages/resources/src/util/nodeBuilder.ts
+++ b/packages/resources/src/util/nodeBuilder.ts
@@ -264,7 +264,9 @@ export function builder(builderProps: BuilderProps): BuilderOutput {
 
     // Get custom esbuild config
     bundle = bundle as FunctionBundleNodejsProps;
-    let customConfig = appEsbuildConfig || bundle.esbuildConfig || {};
+
+    // We need to deep clone so we don't run into mutation issues
+    let customConfig = JSON.parse(JSON.stringify(appEsbuildConfig || bundle.esbuildConfig || {}));
     // note: "esbuildConfig" used to take a string, a path to the user
     //       provided config file. With the new format, esbuildConfig is
     //       configured inline, and the external file can only be used


### PR DESCRIPTION
When providing custom esbuild config options, namely `plugins`, the path provided is a relative path. During the course of the esbuild delegation, the path is modified to an absolute path. The problem is when compiling for multiple functions, the app path will get prefixed each time, resulting in a non-existent absolute path.

As an example:

```
Building Lambda function src/lambda/graphql.main
Before: config/esbuild.js
After: /Users/tylerflint/Code/tylerflint/serverless-app-template/config/esbuild.js

Building Lambda function src/lambda/web.main
Before: /Users/tylerflint/Code/tylerflint/serverless-app-template/config/esbuild.js
After: /Users/tylerflint/Code/tylerflint/serverless-app-template/Users/tylerflint/Code/tylerflint/serverless-app-template/config/esbuild.js
```

The solution is simple, in that a deep clone of the esbuild config prior to delegating to esbuild will ensure this does not happen. 