### PR TITLE
Ensure customConfig is deep cloned to avoid side affects

### DIFF
--- a/packages/cli/scripts/util/cdkHelpers.js
+++ b/packages/cli/scripts/util/cdkHelpers.js
@@ -185,7 +185,7 @@ function runCdkVersionMatch(packageJson, cliInfo) {
 
 async function loadEsbuildConfigOverrides(customConfig) {
   // Handle deprecated string format
-  customConfig = customConfig || {};
+  customConfig = JSON.parse(JSON.stringify(customConfig || {}));
   // note: "esbuildConfig" used to take a string, a path to the user
   //       provided config file. With the new format, esbuildConfig is
   //       configured inline, and the external file can only be used


### PR DESCRIPTION
This PR is a follow-up to #885. Another instance where the custom config object needs to be deep cloned to protect against side affects with multiple function compilations.