### PR TITLE
Add type definitions for Node and ensure that the major version is the same with default runtime

### DIFF
--- a/packages/create-serverless-stack/templates/typescript/package.template.json
+++ b/packages/create-serverless-stack/templates/typescript/package.template.json
@@ -15,7 +15,8 @@
   "devDependencies": {
     "@tsconfig/node14": "^1.0.1",
     "@aws-cdk/assert": "%cdk-version%",
-    "@types/aws-lambda": "^8.10.70"
+    "@types/aws-lambda": "^8.10.70",
+    "@types/node": "<15.0.0"
   },
   "dependencies": {
     "@serverless-stack/cli": "%sst-version%",


### PR DESCRIPTION
Since the nodejs runtime for TypeScript template is now 14, it would be beneficial and even in some cases saving from bugs to add @types/node as dev dependency with the latest version for major being 14.

Because often the type definitions for node is installed without specifying version, and in that case the latest is installed, and usually it is recommended to match the major version with the node version and types.