### PR TITLE
Throw if the permission grant does not exist on the construct

### DIFF
--- a/packages/resources/src/util/permission.ts
+++ b/packages/resources/src/util/permission.ts
@@ -207,6 +207,11 @@ export function attachPermissionsToRole(
     ) {
       const construct = permission[0] as cdk.Construct;
       const methodName = permission[1] as keyof cdk.Construct;
+      if (typeof construct[methodName] !== "function")
+        throw new Error(
+          `The specified grant method is incorrect.
+          Check the available methods that prefixed with grants on the Construct`
+        );
       (construct[methodName] as { (construct: cdk.Construct): void })(role);
     } else {
       logger.debug("permission object", permission);


### PR DESCRIPTION
When an invalid grant is trying to be permitted to a resource, the process will error out trying to call `undefined`, which will result in this error:

```bash
TypeError: construct[methodName] is not a function
```

And it might not be clear to the user why exactly the error is thrown. So I guess it is better to check if the provided grant exists on the construct and is a function, and only then call it, otherwise throw error explaining that a relevant method should exist on the grant.

Example: 
![image](https://user-images.githubusercontent.com/63205993/141661132-e70641a7-7305-467e-a347-7453e18f5c4a.png)
