### PR TITLE
fix: set GOARCH=amd64 in goBuilder

### DIFF
--- a/packages/resources/src/util/goBuilder.ts
+++ b/packages/resources/src/util/goBuilder.ts
@@ -54,6 +54,7 @@ export function builder(builderProps: BuilderProps): BuilderOutput {
       {
         stdio: "inherit",
         env: {
+          GOARCH: "amd64",
           ...process.env,
           GOOS: "linux",
           CGO_ENABLED: "0",


### PR DESCRIPTION
I ran into an issue when trying to build go lambdas on an M1 mac.

I'm pretty sure explicitly setting `GOARCH=amd64` should probably be the default.

Some docs about bundling:

https://github.com/aws/aws-lambda-go/blob/main/README.md

The way the `aws-cdk` package handles this is defaulting to `amd64` and allowing config passed to explicitly set the architecture https://github.com/aws/aws-cdk/blob/master/packages/%40aws-cdk/aws-lambda-go/lib/function.ts#L107

