### PR TITLE
Fix: Move the tracing option to under its relevant JSDOC

### DIFF
--- a/packages/resources/src/Function.ts
+++ b/packages/resources/src/Function.ts
@@ -98,6 +98,7 @@ export interface FunctionProps
    *
    * @default - Defaults to ACTIVE
    */
+  tracing?: lambda.Tracing;
 
   /**
    * Enable local development
@@ -106,7 +107,6 @@ export interface FunctionProps
    */
   enableLiveDev?: boolean;
 
-  tracing?: lambda.Tracing;
   /**
    * Disable bundling with esbuild.
    *


### PR DESCRIPTION
Small fix that moves the `tracing` option to its relevant JSDOC counterpart.