### PR TITLE
Imported DynamoDb with imported Arn

### DIFF
--- a/packages/resources/src/Table.ts
+++ b/packages/resources/src/Table.ts
@@ -320,7 +320,7 @@ export class Table extends cdk.Construct implements ISstConstruct {
 
   public getConstructInfo(): ISstConstructInfo {
     // imported
-    if (!cdk.Token.isUnresolved(this.dynamodbTable.tableName)) {
+    if (this.dynamodbTableType === "IMPORTED") {
       return {
         tableName: this.dynamodbTable.tableName,
       };

--- a/packages/resources/test/Table.test.ts
+++ b/packages/resources/test/Table.test.ts
@@ -88,6 +88,25 @@ test("constructor: dynamodbTable is imported", async () => {
   });
 });
 
+test("constructor: dynamodbTable is imported from imported arn", async () => {
+  const app = new App();
+  app.registerConstruct = jest.fn();
+  const stack = new Stack(app, "stack");
+
+  const tableArn = cdk.Fn.importValue(`MyTableArnExport`);
+  const table = new Table(stack, "Table", {
+    dynamodbTable: dynamodb.Table.fromTableArn(stack, "DDB", tableArn),
+  });
+  expect(table.tableArn).toBeDefined();
+  expect(table.tableName).toBeDefined();
+  expectCdk(stack).to(countResources("AWS::DynamoDB::Table", 0));
+
+  // test construct info
+  expect(app.registerConstruct).toHaveBeenCalledTimes(1);
+  const tableNameToken = (table.getConstructInfo() as any).tableName;
+  expect(cdk.Token.isUnresolved(tableNameToken)).toBeTruthy();
+});
+
 test("constructor: kinesisStream", async () => {
   const stack = new Stack(new App(), "stack");
   const stream = new KinesisStream(stack, "Stream");

--- a/packages/resources/test/Table.test.ts
+++ b/packages/resources/test/Table.test.ts
@@ -61,9 +61,8 @@ test("constructor: dynamodbTable is construct", async () => {
 
   // test construct info
   expect(app.registerConstruct).toHaveBeenCalledTimes(1);
-  expect(table.getConstructInfo()).toStrictEqual({
-    tableLogicalId: "DDBBEFDD151",
-  });
+  const tableNameToken = (table.getConstructInfo() as any).tableName;
+  expect(cdk.Token.isUnresolved(tableNameToken)).toBeTruthy();
 });
 
 test("constructor: dynamodbTable is imported", async () => {


### PR DESCRIPTION
There was a regression somewhere between 0.40 and 0.53 that broke this usage pattern:
```typescript
const tableArn = cdk.Fn.importValue(`${app.stage}:TableArn`);

new Table(this, “Table”, {
  dynamodbTable: cdk.Table.fromTableArn(this, “ImportedTable”, tableArn),
});
```

Here’s the error:
```
TypeError: Cannot read property ‘node’ of undefined
    at DynamoStack.allocateLogicalId (/Users/omi/workspaces/node_modules/@aws-cdk/core/lib/stack.ts:502:31)
    at DynamoStack.getLogicalId (/Users/omi/workspaces/node_modules/@aws-cdk/core/lib/stack.ts:265:28)
    at Table.getConstructInfo (/Users/omi/workspaces/node_modules/@serverless-stack/resources/src/Table.ts:328:38)
    at App.registerConstruct (/Users/omi/workspaces/node_modules/@serverless-stack/resources/src/App.ts:400:29)
    at new Table (/Users/omi/workspaces/node_modules/@serverless-stack/resources/src/Table.ts:200:10)
    at new DynamoStack (/Users/omi/workspaces/sst-services/resources/dynamo.ts:21:28)
    at Object.main (/Users/omi/workspaces/sst-services/index.ts:29:23)
    at Object.<anonymous> (/Users/omi/workspaces/sst-services/.build/run.js:104:16)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
```

Dug into the code a little bit, seems to be going wrong on these lines in SST’s Table construct:
```typescript
  public getConstructInfo(): ISstConstructInfo {
    // imported
    if (!cdk.Token.isUnresolved(this.dynamodbTable.tableName)) {
      return {
        tableName: this.dynamodbTable.tableName,
      };
    }
    // created
    const cfn = this.dynamodbTable.node.defaultChild as dynamodb.CfnTable;
    return {
      tableLogicalId: Stack.of(this).getLogicalId(cfn),
    };
  }
```
Seems like we shouldn’t be hitting the second case for this usage pattern.

To fix this issue, I changed the block to use `dynamodbTableType`, but that changes the behaviour for this usage pattern (and breaks the associated test):
```typescript
const table = new Table(stack, "Table", {
  dynamodbTable: new dynamodb.Table(stack, "DDB", {
    partitionKey: { name: "id", type: dynamodb.AttributeType.STRING },
  }),
});
```

All three constructor usage patterns worked with this change when I deployed them to AWS.

So there are two options I think:
- We accept the above behaviour change and return `tableName` instead of `tableLogicalId` for the above usage (currently implemented)
- We try to keep the old behaviour for that usage pattern, probably by adding an `IMPORTED_ARN` state or something to `dynamodbTableType`
