### PR TITLE
Allow specifying region via .sst/region file

### DIFF
--- a/packages/cli/bin/scripts.js
+++ b/packages/cli/bin/scripts.js
@@ -191,7 +191,7 @@ async function applyConfig(argv) {
   config.name = config.name || DEFAULT_NAME;
   config.stage = await getStage(argv, config);
   config.lint = config.lint === false ? false : DEFAULT_LINT;
-  config.region = argv.region || config.region || DEFAULT_REGION;
+  config.region = getRegion();
   config.typeCheck = config.typeCheck === false ? false : DEFAULT_TYPE_CHECK;
   config.main = config.main || getDefaultMainPath();
   config.esbuildConfig = config.esbuildConfig || DEFAULT_ESBUILD_CONFIG;
@@ -231,6 +231,16 @@ async function getStage(argv, config) {
       }
     );
   });
+}
+
+function getRegion(argv, config) {
+  if (argv.region) return argv.region;
+  if (config.region) return config.region;
+
+  const fromState = State.getRegion(paths.appPath);
+  if (fromState) return fromState;
+
+  return DEFAULT_REGION;
 }
 
 function getDefaultMainPath() {

--- a/packages/cli/bin/scripts.js
+++ b/packages/cli/bin/scripts.js
@@ -235,10 +235,11 @@ async function getStage(argv, config) {
 
 function getRegion(argv, config) {
   if (argv.region) return argv.region;
-  if (config.region) return config.region;
 
   const fromState = State.getRegion(paths.appPath);
   if (fromState) return fromState;
+
+  if (config.region) return config.region;
 
   return DEFAULT_REGION;
 }

--- a/packages/cli/bin/scripts.js
+++ b/packages/cli/bin/scripts.js
@@ -191,7 +191,7 @@ async function applyConfig(argv) {
   config.name = config.name || DEFAULT_NAME;
   config.stage = await getStage(argv, config);
   config.lint = config.lint === false ? false : DEFAULT_LINT;
-  config.region = getRegion();
+  config.region = getRegion(argv, config);
   config.typeCheck = config.typeCheck === false ? false : DEFAULT_TYPE_CHECK;
   config.main = config.main || getDefaultMainPath();
   config.esbuildConfig = config.esbuildConfig || DEFAULT_ESBUILD_CONFIG;

--- a/packages/core/src/state/state.ts
+++ b/packages/core/src/state/state.ts
@@ -21,8 +21,21 @@ function resolveStage(root: string) {
   return resolve(root, "stage");
 }
 
+function resolveRegion(root: string) {
+  return resolve(root, "region");
+}
+
 export function getStage(root: string) {
   const file = resolveStage(root);
+  try {
+    return fs.readFileSync(file).toString().trim();
+  } catch {
+    return null;
+  }
+}
+
+export function getRegion(root: string) {
+  const file = resolveRegion(root);
   try {
     return fs.readFileSync(file).toString().trim();
   } catch {

--- a/www/docs/installation.md
+++ b/www/docs/installation.md
@@ -207,7 +207,7 @@ Let's look at these options in detail.
 
 - **region**
 
-  Defaults for your app and can be overridden using the [`--region`](packages/cli.md#--region) CLI option.
+  Default for your app and can be overridden by creating a `.sst/region` file or using the [`--region`](packages/cli.md#--region) CLI option. Defaults to `us-east-1` if not specified.
 
 - **lint**
 

--- a/www/docs/working-locally.md
+++ b/www/docs/working-locally.md
@@ -40,6 +40,10 @@ If you are working locally, you can remove this option and on the next `sst star
 
 If you are running this in a CI, set the [`--stage`](packages/cli.md#--stage) option explicitly.
 
+#### Overriding the AWS region
+
+By default SST will use the region specified in `sst.json`. You can override this locally by adding a `.sst/region` file that contains the AWS region you want SST to use.
+
 ## Making changes
 
 The sample stack will deploy a Lambda function with an API endpoint. You'll see something like this in the output.


### PR DESCRIPTION
This adds support for specifying the region per developer, by setting it inside a `.sst/region` file like stage instead of specifying it in `sst.json`

In terms of precedence I decided to put the `region` file before `sst.json` so that things progressively get more specific. You can have a default region for the team checked in, but a developer can choose to override it in their env.