### PR TITLE
added external custom domain support to Api construct

### DIFF
--- a/packages/resources/src/util/apiGatewayV2Domain.ts
+++ b/packages/resources/src/util/apiGatewayV2Domain.ts
@@ -29,195 +29,246 @@ export function buildCustomDomainData(
   if (customDomain === undefined) {
     return;
   }
-
-  // To be implemented: to allow more flexible use cases, SST should support 3 more use cases:
-  //  1. Allow user passing in `hostedZone` object. The use case is when there are multiple
-  //     HostedZones with the same domain, but one is public, and one is private.
-  //  2. Allow user passing in `certificate` object. The use case is for user to create wildcard
-  //     certificate or using an imported certificate.
-  //  3. Allow user passing in `apigDomain` object. The use case is a user creates multiple API
-  //     endpoints, and is mapping them under the same custom domain. `sst.Api` needs to expose the
-  //     `apigDomain` construct created in the first Api, and lets user pass it in when creating
-  //     the second Api.
-
-  let domainName,
-    hostedZone,
-    hostedZoneDomain,
-    certificate,
-    apigDomain,
-    mappingKey,
-    isExternalDomain;
-  let isApigDomainCreated = false;
-  let isCertificatedCreated = false;
-
-  function createDomain(
-    domainName: string,
-    certificate: acm.ICertificate
-  ): apig.IDomainName {
-    return new apig.DomainName(scope, "DomainName", {
-      domainName,
-      certificate,
-    });
-  }
-
-  ///////////////////
-  // Parse input
-  ///////////////////
-
   // customDomain is a string
-  if (typeof customDomain === "string") {
-    // validate: customDomain is a TOKEN string
-    // ie. imported SSM value: ssm.StringParameter.valueForStringParameter()
-    if (cdk.Token.isUnresolved(customDomain)) {
-      throw new Error(
-        `You also need to specify the "hostedZone" if the "domainName" is passed in as a reference.`
-      );
-    }
-
-    domainName = customDomain.toLowerCase();
-    hostedZoneDomain = customDomain.toLowerCase().split(".").slice(1).join(".");
+  else if (typeof customDomain === "string") {
+    return buildDataForStringInput(scope, customDomain);
   }
-
   // customDomain.domainName not exists
   else if (!customDomain.domainName) {
     throw new Error(`Missing "domainName" in sst.Api's customDomain setting`);
   }
-
   // customDomain.domainName is a string
   else if (typeof customDomain.domainName === "string") {
-    // parse customDomain.domainName
-    if (cdk.Token.isUnresolved(customDomain.domainName)) {
-      // If customDomain is a TOKEN string, "hostedZone" has to be passed in. This
-      // is because "hostedZone" cannot be parsed from a TOKEN value.
-      if (!customDomain.hostedZone) {
-        throw new Error(
-          `You also need to specify the "hostedZone" if the "domainName" is passed in as a reference.`
-        );
-      }
-    } else {
-      domainName = customDomain.domainName.toLowerCase();
-    }
-
-    domainName = customDomain.domainName;
-
-    // check if the domain is external
-    if (customDomain.isExternalDomain) {
-      // if it is external, then a certificate is required
-      if (!customDomain.certificate) {
-        throw new Error(
-          `A valid certificate is required when "isExternalDomain" is set to "true".`
-        );
-      }
-      // if it is external, then the hostedZone is not required
-      if (customDomain.hostedZone) {
-        throw new Error(
-          `Hosted zones can only be configured for domains hosted on Amazon Route 53. Do not set the "customDomain.hostedZone" when "isExternalDomain" is enabled.`
-        );
-      }
-    } else {
-      // parse customDomain.hostedZone
-      if (!customDomain.hostedZone) {
-        hostedZoneDomain = domainName
-          .toLowerCase()
-          .split(".")
-          .slice(1)
-          .join(".");
-      } else if (typeof customDomain.hostedZone === "string") {
-        hostedZoneDomain = customDomain.hostedZone;
-      } else {
-        hostedZone = customDomain.hostedZone;
-      }
-    }
-
-    isExternalDomain = customDomain.isExternalDomain;
-    certificate = customDomain.certificate;
-    mappingKey = customDomain.path;
+    return customDomain.isExternalDomain
+      ? buildDataForExternalDomainInput(scope, customDomain)
+      : buildDataForInternalDomainInput(scope, customDomain);
   }
-
   // customDomain.domainName is a construct
-  else {
-    if (customDomain.hostedZone) {
-      throw new Error(
-        `Cannot configure the "hostedZone" when the "domainName" is a construct`
-      );
-    }
-    if (customDomain.certificate) {
-      throw new Error(
-        `Cannot configure the "certificate" when the "domainName" is a construct`
-      );
-    }
+  return buildDataForConstructInput(scope, customDomain);
+}
 
-    domainName = customDomain.domainName.name;
-    apigDomain = customDomain.domainName;
-    mappingKey = customDomain.path;
+function buildDataForStringInput(
+  scope: cdk.Construct,
+  customDomain: string
+): CustomDomainData {
+  // validate: customDomain is a TOKEN string
+  // ie. imported SSM value: ssm.StringParameter.valueForStringParameter()
+  if (cdk.Token.isUnresolved(customDomain)) {
+    throw new Error(
+      `You also need to specify the "hostedZone" if the "domainName" is passed in as a reference.`
+    );
   }
 
-  ///////////////////
-  // Create domain
-  ///////////////////
-  if (!apigDomain && domainName) {
-    if (isExternalDomain && certificate) {
-      // create a custom domain with certificate in API Gateway
-      apigDomain = createDomain(domainName, certificate);
-    } else {
-      // Look up hosted zone
-      if (!hostedZone && hostedZoneDomain) {
-        hostedZone = route53.HostedZone.fromLookup(scope, "HostedZone", {
-          domainName: hostedZoneDomain,
-        });
-      }
-      // Create certificate
-      if (!certificate) {
-        certificate = new acm.Certificate(scope, "Certificate", {
-          domainName,
-          validation: acm.CertificateValidation.fromDns(hostedZone),
-        });
-        isCertificatedCreated = true;
-      }
+  assertDomainNameIsLowerCase(customDomain);
 
-      // Create custom domain in API Gateway
-      apigDomain = createDomain(domainName, certificate);
-
-      // create DNS record
-      const record = new route53.ARecord(scope, "AliasRecord", {
-        recordName: domainName,
-        zone: hostedZone as route53.IHostedZone,
-        target: route53.RecordTarget.fromAlias(
-          new route53Targets.ApiGatewayv2DomainProperties(
-            apigDomain.regionalDomainName,
-            apigDomain.regionalHostedZoneId
-          )
-        ),
-      });
-      // note: If domainName is a TOKEN string ie. ${TOKEN..}, the route53.ARecord
-      //       construct will append ".${hostedZoneName}" to the end of the domain.
-      //       This is because the construct tries to check if the record name
-      //       ends with the domain name. If not, it will append the domain name.
-      //       So, we need remove this behavior.
-      if (cdk.Token.isUnresolved(domainName)) {
-        const cfnRecord = record.node.defaultChild as route53.CfnRecordSet;
-        cfnRecord.name = domainName;
-      }
-    }
-
-    isApigDomainCreated = true;
-  }
+  const domainName = customDomain;
+  const hostedZoneDomain = domainName.split(".").slice(1).join(".");
+  const hostedZone = lookupHostedZone(scope, hostedZoneDomain);
+  const certificate = createCertificate(scope, domainName, hostedZone);
+  const apigDomain = createApigDomain(scope, domainName, certificate);
+  const record = createARecord(scope, hostedZone, domainName, apigDomain);
 
   return {
-    apigDomain: apigDomain as apig.IDomainName,
-    mappingKey,
+    apigDomain,
     certificate,
-    isApigDomainCreated,
-    isCertificatedCreated,
-    // Note: If mapping key is set, the URL needs a trailing slash. Without the
-    //       trailing slash, the API fails with the error
-    //       {"message":"Not Found"}
-    url: mappingKey ? `${domainName}/${mappingKey}/` : domainName,
+    isApigDomainCreated: true,
+    isCertificatedCreated: true,
+    url: buildDomainUrl(domainName),
   };
 }
 
-// function assertDomainNameIsLowerCase(domainName: string): void {
-//   if (domainName !== domainName.toLowerCase()) {
-//     throw new Error(`The domain name needs to be in lowercase`);
-//   }
-// }
+function buildDataForInternalDomainInput(
+  scope: cdk.Construct,
+  customDomain: CustomDomainProps
+): CustomDomainData {
+  // If customDomain is a TOKEN string, "hostedZone" has to be passed in. This
+  // is because "hostedZone" cannot be parsed from a TOKEN value.
+  if (cdk.Token.isUnresolved(customDomain.domainName)) {
+    if (!customDomain.hostedZone) {
+      throw new Error(
+        `You also need to specify the "hostedZone" if the "domainName" is passed in as a reference.`
+      );
+    }
+  } else {
+    assertDomainNameIsLowerCase(customDomain.domainName as string);
+  }
+
+  const domainName = customDomain.domainName as string;
+
+  // Lookup hosted zone
+  // Note: Allow user passing in `hostedZone` object. The use case is when
+  //       there are multiple HostedZones with the same domain, but one is
+  //       public, and one is private.
+
+  let hostedZone;
+  if (!customDomain.hostedZone) {
+    const hostedZoneDomain = domainName.split(".").slice(1).join(".");
+    hostedZone = lookupHostedZone(scope, hostedZoneDomain);
+  } else if (typeof customDomain.hostedZone === "string") {
+    const hostedZoneDomain = customDomain.hostedZone;
+    hostedZone = lookupHostedZone(scope, hostedZoneDomain);
+  } else {
+    hostedZone = customDomain.hostedZone;
+  }
+
+  // Create certificate
+  // Note: Allow user passing in `certificate` object. The use case is for
+  //       user to create wildcard certificate or using an imported certificate.
+  let certificate, isCertificatedCreated;
+  if (customDomain.certificate) {
+    certificate = customDomain.certificate;
+    isCertificatedCreated = false;
+  } else {
+    certificate = createCertificate(scope, domainName, hostedZone);
+    isCertificatedCreated = true;
+  }
+
+  const apigDomain = createApigDomain(scope, domainName, certificate);
+  const mappingKey = customDomain.path;
+  const record = createARecord(scope, hostedZone, domainName, apigDomain);
+
+  return {
+    apigDomain,
+    mappingKey,
+    certificate,
+    isApigDomainCreated: true,
+    isCertificatedCreated,
+    url: buildDomainUrl(domainName, mappingKey),
+  };
+}
+
+function buildDataForExternalDomainInput(
+  scope: cdk.Construct,
+  customDomain: CustomDomainProps
+): CustomDomainData {
+  // if it is external, then a certificate is required
+  if (!customDomain.certificate) {
+    throw new Error(
+      `A valid certificate is required when "isExternalDomain" is set to "true".`
+    );
+  }
+  // if it is external, then the hostedZone is not required
+  if (customDomain.hostedZone) {
+    throw new Error(
+      `Hosted zones can only be configured for domains hosted on Amazon Route 53. Do not set the "customDomain.hostedZone" when "isExternalDomain" is enabled.`
+    );
+  }
+
+  const domainName = customDomain.domainName as string;
+  assertDomainNameIsLowerCase(domainName);
+  const certificate = customDomain.certificate;
+  const apigDomain = createApigDomain(scope, domainName, certificate);
+  const mappingKey = customDomain.path;
+
+  return {
+    apigDomain,
+    mappingKey,
+    certificate,
+    isApigDomainCreated: true,
+    isCertificatedCreated: false,
+    url: buildDomainUrl(domainName, mappingKey),
+  };
+}
+
+function buildDataForConstructInput(
+  scope: cdk.Construct,
+  customDomain: CustomDomainProps
+): CustomDomainData {
+  //  Allow user passing in `apigDomain` object. The use case is a user creates
+  //  multiple API endpoints, and is mapping them under the same custom domain.
+  //  `sst.Api` needs to expose the `apigDomain` construct created in the first
+  //  Api, and lets user pass it in when creating the second Api.
+
+  if (customDomain.hostedZone) {
+    throw new Error(
+      `Cannot configure the "hostedZone" when the "domainName" is a construct`
+    );
+  }
+  if (customDomain.certificate) {
+    throw new Error(
+      `Cannot configure the "certificate" when the "domainName" is a construct`
+    );
+  }
+
+  const apigDomain = customDomain.domainName as apig.IDomainName;
+  const domainName = apigDomain.name;
+  const mappingKey = customDomain.path;
+
+  return {
+    apigDomain,
+    mappingKey,
+    certificate: undefined,
+    isApigDomainCreated: false,
+    isCertificatedCreated: false,
+    url: buildDomainUrl(domainName, mappingKey),
+  };
+}
+
+function lookupHostedZone(scope: cdk.Construct, hostedZoneDomain: string) {
+  return route53.HostedZone.fromLookup(scope, "HostedZone", {
+    domainName: hostedZoneDomain,
+  });
+}
+
+function createCertificate(
+  scope: cdk.Construct,
+  domainName: string,
+  hostedZone: route53.IHostedZone
+) {
+  return new acm.Certificate(scope, "Certificate", {
+    domainName,
+    validation: acm.CertificateValidation.fromDns(hostedZone),
+  });
+}
+
+function createApigDomain(
+  scope: cdk.Construct,
+  domainName: string,
+  certificate: acm.ICertificate
+) {
+  return new apig.DomainName(scope, "DomainName", {
+    domainName,
+    certificate,
+  });
+}
+
+function createARecord(
+  scope: cdk.Construct,
+  hostedZone: route53.IHostedZone,
+  domainName: string,
+  apigDomain: apig.IDomainName
+) {
+  // create DNS record
+  const record = new route53.ARecord(scope, "AliasRecord", {
+    recordName: domainName,
+    zone: hostedZone,
+    target: route53.RecordTarget.fromAlias(
+      new route53Targets.ApiGatewayv2DomainProperties(
+        apigDomain.regionalDomainName,
+        apigDomain.regionalHostedZoneId
+      )
+    ),
+  });
+  // note: If domainName is a TOKEN string ie. ${TOKEN..}, the route53.ARecord
+  //       construct will append ".${hostedZoneName}" to the end of the domain.
+  //       This is because the construct tries to check if the record name
+  //       ends with the domain name. If not, it will append the domain name.
+  //       So, we need remove this behavior.
+  if (cdk.Token.isUnresolved(domainName)) {
+    const cfnRecord = record.node.defaultChild as route53.CfnRecordSet;
+    cfnRecord.name = domainName;
+  }
+}
+
+function buildDomainUrl(domainName: string, mappingKey?: string) {
+  // Note: If mapping key is set, the URL needs a trailing slash. Without the
+  //       trailing slash, the API fails with the error
+  //       {"message":"Not Found"}
+  return mappingKey ? `${domainName}/${mappingKey}/` : domainName;
+}
+
+function assertDomainNameIsLowerCase(domainName: string): void {
+  if (domainName !== domainName.toLowerCase()) {
+    throw new Error(`The domain name needs to be in lowercase`);
+  }
+}

--- a/packages/resources/src/util/apiGatewayV2Domain.ts
+++ b/packages/resources/src/util/apiGatewayV2Domain.ts
@@ -10,6 +10,7 @@ export interface CustomDomainProps {
   readonly hostedZone?: string | route53.IHostedZone;
   readonly certificate?: acm.ICertificate;
   readonly path?: string;
+  readonly isExternalDomain?: boolean;
 }
 
 export interface CustomDomainData {
@@ -44,7 +45,8 @@ export function buildCustomDomainData(
     hostedZoneDomain,
     certificate,
     apigDomain,
-    mappingKey;
+    mappingKey,
+    isExternalDomain;
   let isApigDomainCreated = false;
   let isCertificatedCreated = false;
 
@@ -89,8 +91,23 @@ export function buildCustomDomainData(
       assertDomainNameIsLowerCase(domainName);
     }
 
+    // check if the domain is external
+    if (customDomain.isExternalDomain) {
+      // if it is external, then a certificate is required
+      if (!customDomain.certificate) {
+        throw new Error(
+          `A valid certificate is required when "isExternalDomain" is set to "true".`
+        );
+      }
+      // if it is external, then the hostedZone is not required
+      if (customDomain.hostedZone) {
+        throw new Error(
+          `Hosted zones can only be configured for domains hosted on Amazon Route 53. Do not set the "customDomain.hostedZone" when "isExternalDomain" is enabled.`
+        );
+      }
+    }
     // parse customDomain.hostedZone
-    if (!customDomain.hostedZone) {
+    else if (!customDomain.hostedZone) {
       hostedZoneDomain = domainName.split(".").slice(1).join(".");
     } else if (typeof customDomain.hostedZone === "string") {
       hostedZoneDomain = customDomain.hostedZone;
@@ -98,6 +115,7 @@ export function buildCustomDomainData(
       hostedZone = customDomain.hostedZone;
     }
 
+    isExternalDomain = customDomain.isExternalDomain;
     certificate = customDomain.certificate;
     mappingKey = customDomain.path;
   }
@@ -146,25 +164,27 @@ export function buildCustomDomainData(
       certificate,
     });
 
-    // Create DNS record
-    const record = new route53.ARecord(scope, "AliasRecord", {
-      recordName: domainName,
-      zone: hostedZone as route53.IHostedZone,
-      target: route53.RecordTarget.fromAlias(
-        new route53Targets.ApiGatewayv2DomainProperties(
-          apigDomain.regionalDomainName,
-          apigDomain.regionalHostedZoneId
-        )
-      ),
-    });
-    // note: If domainName is a TOKEN string ie. ${TOKEN..}, the route53.ARecord
-    //       construct will append ".${hostedZoneName}" to the end of the domain.
-    //       This is because the construct tries to check if the record name
-    //       ends with the domain name. If not, it will append the domain name.
-    //       So, we need remove this behavior.
-    if (cdk.Token.isUnresolved(domainName)) {
-      const cfnRecord = record.node.defaultChild as route53.CfnRecordSet;
-      cfnRecord.name = domainName;
+    // Create DNS record only if the domain is not external
+    if (!isExternalDomain) {
+      const record = new route53.ARecord(scope, "AliasRecord", {
+        recordName: domainName,
+        zone: hostedZone as route53.IHostedZone,
+        target: route53.RecordTarget.fromAlias(
+          new route53Targets.ApiGatewayv2DomainProperties(
+            apigDomain.regionalDomainName,
+            apigDomain.regionalHostedZoneId
+          )
+        ),
+      });
+      // note: If domainName is a TOKEN string ie. ${TOKEN..}, the route53.ARecord
+      //       construct will append ".${hostedZoneName}" to the end of the domain.
+      //       This is because the construct tries to check if the record name
+      //       ends with the domain name. If not, it will append the domain name.
+      //       So, we need remove this behavior.
+      if (cdk.Token.isUnresolved(domainName)) {
+        const cfnRecord = record.node.defaultChild as route53.CfnRecordSet;
+        cfnRecord.name = domainName;
+      }
     }
 
     isApigDomainCreated = true;

--- a/packages/resources/src/util/apiGatewayV2Domain.ts
+++ b/packages/resources/src/util/apiGatewayV2Domain.ts
@@ -74,9 +74,8 @@ export function buildCustomDomainData(
       );
     }
 
-    domainName = customDomain;
-    assertDomainNameIsLowerCase(domainName);
-    hostedZoneDomain = customDomain.split(".").slice(1).join(".");
+    domainName = customDomain.toLowerCase();
+    hostedZoneDomain = customDomain.toLowerCase().split(".").slice(1).join(".");
   }
 
   // customDomain.domainName not exists
@@ -96,7 +95,7 @@ export function buildCustomDomainData(
         );
       }
     } else {
-      assertDomainNameIsLowerCase(customDomain.domainName);
+      domainName = customDomain.domainName.toLowerCase();
     }
 
     domainName = customDomain.domainName;
@@ -118,7 +117,11 @@ export function buildCustomDomainData(
     } else {
       // parse customDomain.hostedZone
       if (!customDomain.hostedZone) {
-        hostedZoneDomain = domainName.split(".").slice(1).join(".");
+        hostedZoneDomain = domainName
+          .toLowerCase()
+          .split(".")
+          .slice(1)
+          .join(".");
       } else if (typeof customDomain.hostedZone === "string") {
         hostedZoneDomain = customDomain.hostedZone;
       } else {
@@ -213,8 +216,8 @@ export function buildCustomDomainData(
   };
 }
 
-function assertDomainNameIsLowerCase(domainName: string): void {
-  if (domainName !== domainName.toLowerCase()) {
-    throw new Error(`The domain name needs to be in lowercase`);
-  }
-}
+// function assertDomainNameIsLowerCase(domainName: string): void {
+//   if (domainName !== domainName.toLowerCase()) {
+//     throw new Error(`The domain name needs to be in lowercase`);
+//   }
+// }

--- a/packages/resources/src/util/apiGatewayV2Domain.ts
+++ b/packages/resources/src/util/apiGatewayV2Domain.ts
@@ -1,4 +1,4 @@
-import { Construct } from 'constructs';
+import { Construct } from "constructs";
 import * as cdk from "aws-cdk-lib";
 import * as apig from "@aws-cdk/aws-apigatewayv2-alpha";
 import * as route53 from "aws-cdk-lib/aws-route53";
@@ -48,7 +48,7 @@ export function buildCustomDomainData(
 }
 
 function buildDataForStringInput(
-  scope: cdk.Construct,
+  scope: Construct,
   customDomain: string
 ): CustomDomainData {
   // validate: customDomain is a TOKEN string
@@ -78,7 +78,7 @@ function buildDataForStringInput(
 }
 
 function buildDataForInternalDomainInput(
-  scope: cdk.Construct,
+  scope: Construct,
   customDomain: CustomDomainProps
 ): CustomDomainData {
   // If customDomain is a TOKEN string, "hostedZone" has to be passed in. This
@@ -138,7 +138,7 @@ function buildDataForInternalDomainInput(
 }
 
 function buildDataForExternalDomainInput(
-  scope: cdk.Construct,
+  scope: Construct,
   customDomain: CustomDomainProps
 ): CustomDomainData {
   // if it is external, then a certificate is required
@@ -171,7 +171,7 @@ function buildDataForExternalDomainInput(
 }
 
 function buildDataForConstructInput(
-  scope: cdk.Construct,
+  scope: Construct,
   customDomain: CustomDomainProps
 ): CustomDomainData {
   //  Allow user passing in `apigDomain` object. The use case is a user creates
@@ -204,14 +204,14 @@ function buildDataForConstructInput(
   };
 }
 
-function lookupHostedZone(scope: cdk.Construct, hostedZoneDomain: string) {
+function lookupHostedZone(scope: Construct, hostedZoneDomain: string) {
   return route53.HostedZone.fromLookup(scope, "HostedZone", {
     domainName: hostedZoneDomain,
   });
 }
 
 function createCertificate(
-  scope: cdk.Construct,
+  scope: Construct,
   domainName: string,
   hostedZone: route53.IHostedZone
 ) {
@@ -222,7 +222,7 @@ function createCertificate(
 }
 
 function createApigDomain(
-  scope: cdk.Construct,
+  scope: Construct,
   domainName: string,
   certificate: acm.ICertificate
 ) {
@@ -233,7 +233,7 @@ function createApigDomain(
 }
 
 function createARecord(
-  scope: cdk.Construct,
+  scope: Construct,
   hostedZone: route53.IHostedZone,
   domainName: string,
   apigDomain: apig.IDomainName

--- a/packages/resources/test/Api.test.ts
+++ b/packages/resources/test/Api.test.ts
@@ -368,14 +368,14 @@ test("constructor: customDomain is string", async () => {
   });
 });
 
-test("constructor: customDomain is string (uppercase error)", async () => {
-  const stack = new Stack(new App(), "stack");
-  expect(() => {
-    new Api(stack, "Api", {
-      customDomain: "API.domain.com",
-    });
-  }).toThrow(/The domain name needs to be in lowercase/);
-});
+// test("constructor: customDomain is string (uppercase error)", async () => {
+//   const stack = new Stack(new App(), "stack");
+//   expect(() => {
+//     new Api(stack, "Api", {
+//       customDomain: "API.domain.com",
+//     });
+//   }).toThrow(/The domain name needs to be in lowercase/);
+// });
 
 test("constructor: customDomain is string (imported ssm)", async () => {
   const stack = new Stack(new App(), "stack");
@@ -437,16 +437,16 @@ test("constructor: customDomain.domainName is string", async () => {
   });
 });
 
-test("constructor: customDomain.domainName is string (uppercase error)", async () => {
-  const stack = new Stack(new App(), "stack");
-  expect(() => {
-    new Api(stack, "Api", {
-      customDomain: {
-        domainName: "API.domain.com",
-      },
-    });
-  }).toThrow(/The domain name needs to be in lowercase/);
-});
+// test("constructor: customDomain.domainName is string (uppercase error)", async () => {
+//   const stack = new Stack(new App(), "stack");
+//   expect(() => {
+//     new Api(stack, "Api", {
+//       customDomain: {
+//         domainName: "API.domain.com",
+//       },
+//     });
+//   }).toThrow(/The domain name needs to be in lowercase/);
+// });
 
 test("constructor: customDomain.domainName is string (imported ssm), hostedZone undefined", async () => {
   const stack = new Stack(new App(), "stack");

--- a/packages/resources/test/Api.test.ts
+++ b/packages/resources/test/Api.test.ts
@@ -1,9 +1,4 @@
-import {
-  ABSENT,
-  objectLike,
-  countResources,
-  hasResource,
-} from "./helper";
+import { ABSENT, objectLike, countResources, hasResource } from "./helper";
 import * as acm from "aws-cdk-lib/aws-certificatemanager";
 import * as apig from "@aws-cdk/aws-apigatewayv2-alpha";
 import * as apigAuthorizers from "@aws-cdk/aws-apigatewayv2-authorizers-alpha";
@@ -307,7 +302,7 @@ test("constructor: stages", async () => {
   });
 });
 
-test("constructor: customDomain is string", async () => {
+test("customDomain is string", async () => {
   const stack = new Stack(new App(), "stack");
   route53.HostedZone.fromLookup = jest
     .fn()
@@ -368,7 +363,7 @@ test("constructor: customDomain is string", async () => {
   });
 });
 
-test("constructor: customDomain is string (uppercase error)", async () => {
+test("customDomain is string (uppercase error)", async () => {
   const stack = new Stack(new App(), "stack");
   expect(() => {
     new Api(stack, "Api", {
@@ -377,7 +372,7 @@ test("constructor: customDomain is string (uppercase error)", async () => {
   }).toThrow(/The domain name needs to be in lowercase/);
 });
 
-test("constructor: customDomain is string (imported ssm)", async () => {
+test("customDomain is string (imported ssm)", async () => {
   const stack = new Stack(new App(), "stack");
   const domain = ssm.StringParameter.valueForStringParameter(stack, "domain");
   expect(() => {
@@ -389,7 +384,7 @@ test("constructor: customDomain is string (imported ssm)", async () => {
   );
 });
 
-test("constructor: customDomain.domainName is string", async () => {
+test("customDomain.domainName is string", async () => {
   const stack = new Stack(new App(), "stack");
   route53.HostedZone.fromLookup = jest
     .fn()
@@ -437,7 +432,7 @@ test("constructor: customDomain.domainName is string", async () => {
   });
 });
 
-test("constructor: customDomain.domainName is string (uppercase error)", async () => {
+test("customDomain.domainName is string (uppercase error)", async () => {
   const stack = new Stack(new App(), "stack");
   expect(() => {
     new Api(stack, "Api", {
@@ -448,7 +443,7 @@ test("constructor: customDomain.domainName is string (uppercase error)", async (
   }).toThrow(/The domain name needs to be in lowercase/);
 });
 
-test("constructor: customDomain.domainName is string (imported ssm), hostedZone undefined", async () => {
+test("customDomain.domainName is string (imported ssm), hostedZone undefined", async () => {
   const stack = new Stack(new App(), "stack");
   const domain = ssm.StringParameter.valueForStringParameter(stack, "domain");
   expect(() => {
@@ -474,22 +469,18 @@ test("customDomain: isExternalDomain true", async () => {
     },
   });
   expect(site.customDomainUrl).toEqual("https://www.domain.com");
-  expectCdk(stack).to(
-    haveResource("AWS::ApiGatewayV2::Api", {
-      Name: "dev-my-app-Site",
-    })
-  );
-  expectCdk(stack).to(
-    haveResource("AWS::ApiGatewayV2::DomainName", {
-      DomainName: "www.domain.com",
-      DomainNameConfigurations: [
-        {
-          CertificateArn: { Ref: "Cert5C9FAEC1" },
-          EndpointType: "REGIONAL",
-        },
-      ],
-    })
-  );
+  hasResource(stack, "AWS::ApiGatewayV2::Api", {
+    Name: "dev-my-app-Site",
+  });
+  hasResource(stack, "AWS::ApiGatewayV2::DomainName", {
+    DomainName: "www.domain.com",
+    DomainNameConfigurations: [
+      {
+        CertificateArn: { Ref: "Cert5C9FAEC1" },
+        EndpointType: "REGIONAL",
+      },
+    ],
+  });
 });
 
 test("customDomain: isExternalDomain true and no certificate", async () => {
@@ -524,7 +515,7 @@ test("customDomain: isExternalDomain true and hostedZone set", async () => {
   );
 });
 
-test("constructor: customDomain.domainName is string (imported ssm), hostedZone defined", async () => {
+test("customDomain.domainName is string (imported ssm), hostedZone defined", async () => {
   const stack = new Stack(new App(), "stack");
   const domain = ssm.StringParameter.valueForStringParameter(stack, "domain");
   new Api(stack, "Api", {
@@ -556,7 +547,7 @@ test("constructor: customDomain.domainName is string (imported ssm), hostedZone 
   });
 });
 
-test("constructor: customDomain.hostedZone-generated-from-minimal-domainName", async () => {
+test("customDomain.hostedZone-generated-from-minimal-domainName", async () => {
   const stack = new Stack(new App(), "stack");
   route53.HostedZone.fromLookup = jest
     .fn()
@@ -575,7 +566,7 @@ test("constructor: customDomain.hostedZone-generated-from-minimal-domainName", a
   });
 });
 
-test("constructor: customDomain.hostedZone-generated-from-full-domainName", async () => {
+test("customDomain.hostedZone-generated-from-full-domainName", async () => {
   const stack = new Stack(new App(), "stack");
   route53.HostedZone.fromLookup = jest
     .fn()
@@ -596,7 +587,7 @@ test("constructor: customDomain.hostedZone-generated-from-full-domainName", asyn
   });
 });
 
-test("constructor: customDomain props-redefined", async () => {
+test("customDomain props-redefined", async () => {
   const stack = new Stack(new App(), "stack");
   expect(() => {
     new Api(stack, "Api", {
@@ -611,7 +602,7 @@ test("constructor: customDomain props-redefined", async () => {
   );
 });
 
-test("constructor: customDomain.domainName-apigDomainName", async () => {
+test("customDomain.domainName-apigDomainName", async () => {
   const stack = new Stack(new App(), "stack");
   apig.DomainName.fromDomainNameAttributes = jest
     .fn()
@@ -660,7 +651,7 @@ test("constructor: customDomain.domainName-apigDomainName", async () => {
   countResources(stack, "AWS::Route53::HostedZone", 0);
 });
 
-test("constructor: customDomain.domainName-apigDomainName-hostedZone-redefined-error", async () => {
+test("customDomain.domainName-apigDomainName-hostedZone-redefined-error", async () => {
   const stack = new Stack(new App(), "stack");
   apig.DomainName.fromDomainNameAttributes = jest
     .fn()
@@ -693,7 +684,7 @@ test("constructor: customDomain.domainName-apigDomainName-hostedZone-redefined-e
   );
 });
 
-test("constructor: customDomain.domainName-apigDomainName-certificate-redefined-error", async () => {
+test("customDomain.domainName-apigDomainName-certificate-redefined-error", async () => {
   const stack = new Stack(new App(), "stack");
   apig.DomainName.fromDomainNameAttributes = jest
     .fn()
@@ -763,9 +754,13 @@ test("defaultAuthorizationType-JWT-userpool", async () => {
   const userPoolClient = userPool.addClient("UserPoolClient");
   new Api(stack, "Api", {
     defaultAuthorizationType: ApiAuthorizationType.JWT,
-    defaultAuthorizer: new apigAuthorizers.HttpUserPoolAuthorizer("Authorizer", userPool, {
-      userPoolClients: [userPoolClient],
-    }),
+    defaultAuthorizer: new apigAuthorizers.HttpUserPoolAuthorizer(
+      "Authorizer",
+      userPool,
+      {
+        userPoolClients: [userPoolClient],
+      }
+    ),
     defaultAuthorizationScopes: ["user.id", "user.email"],
     routes: {
       "GET /": "test/lambda.handler",
@@ -802,9 +797,13 @@ test("defaultAuthorizationType-JWT-auth0", async () => {
   const stack = new Stack(new App(), "stack");
   new Api(stack, "Api", {
     defaultAuthorizationType: ApiAuthorizationType.JWT,
-    defaultAuthorizer: new apigAuthorizers.HttpJwtAuthorizer("Authorizer", "https://abc.us.auth0.com", {
-      jwtAudience: ["123"],
-    }),
+    defaultAuthorizer: new apigAuthorizers.HttpJwtAuthorizer(
+      "Authorizer",
+      "https://abc.us.auth0.com",
+      {
+        jwtAudience: ["123"],
+      }
+    ),
     defaultAuthorizationScopes: ["user.id", "user.email"],
     routes: {
       "GET /": "test/lambda.handler",
@@ -848,10 +847,14 @@ test("defaultAuthorizationType-CUSTOM", async () => {
   });
   new Api(stack, "Api", {
     defaultAuthorizationType: ApiAuthorizationType.CUSTOM,
-    defaultAuthorizer: new apigAuthorizers.HttpLambdaAuthorizer("Authorizer", handler, {
-      authorizerName: "LambdaAuthorizer",
-      responseTypes: [apigAuthorizers.HttpLambdaResponseType.SIMPLE],
-    }),
+    defaultAuthorizer: new apigAuthorizers.HttpLambdaAuthorizer(
+      "Authorizer",
+      handler,
+      {
+        authorizerName: "LambdaAuthorizer",
+        responseTypes: [apigAuthorizers.HttpLambdaResponseType.SIMPLE],
+      }
+    ),
     routes: {
       "GET /": "test/lambda.handler",
     },
@@ -1328,9 +1331,13 @@ test("routes: ApiFunctionRouteProps-authorizationType-override-JWT-by-NONE", asy
   const stack = new Stack(app, "stack");
   new Api(stack, "Api", {
     defaultAuthorizationType: ApiAuthorizationType.JWT,
-    defaultAuthorizer: new apigAuthorizers.HttpJwtAuthorizer("Authorizer", "https://abc.us.auth0.com", {
-      jwtAudience: ["123"],
-    }),
+    defaultAuthorizer: new apigAuthorizers.HttpJwtAuthorizer(
+      "Authorizer",
+      "https://abc.us.auth0.com",
+      {
+        jwtAudience: ["123"],
+      }
+    ),
     routes: {
       "GET /": {
         function: "test/lambda.handler",
@@ -1348,17 +1355,25 @@ test("routes: ApiFunctionRouteProps-authorizationType-override-JWT-by-JWT", asyn
   const stack = new Stack(app, "stack");
   new Api(stack, "Api", {
     defaultAuthorizationType: ApiAuthorizationType.JWT,
-    defaultAuthorizer: new apigAuthorizers.HttpJwtAuthorizer("Authorizer", "https://abc.us.auth0.com", {
-      jwtAudience: ["123"],
-    }),
+    defaultAuthorizer: new apigAuthorizers.HttpJwtAuthorizer(
+      "Authorizer",
+      "https://abc.us.auth0.com",
+      {
+        jwtAudience: ["123"],
+      }
+    ),
     defaultAuthorizationScopes: ["user.id", "user.email"],
     routes: {
       "GET /": {
         function: "test/lambda.handler",
         authorizationType: ApiAuthorizationType.JWT,
-        authorizer: new apigAuthorizers.HttpJwtAuthorizer("Authorizer", "https://xyz.us.auth0.com", {
-          jwtAudience: ["234"],
-        }),
+        authorizer: new apigAuthorizers.HttpJwtAuthorizer(
+          "Authorizer",
+          "https://xyz.us.auth0.com",
+          {
+            jwtAudience: ["234"],
+          }
+        ),
         authorizationScopes: ["user.profile"],
       },
     },

--- a/packages/resources/test/Api.test.ts
+++ b/packages/resources/test/Api.test.ts
@@ -368,14 +368,14 @@ test("constructor: customDomain is string", async () => {
   });
 });
 
-// test("constructor: customDomain is string (uppercase error)", async () => {
-//   const stack = new Stack(new App(), "stack");
-//   expect(() => {
-//     new Api(stack, "Api", {
-//       customDomain: "API.domain.com",
-//     });
-//   }).toThrow(/The domain name needs to be in lowercase/);
-// });
+test("constructor: customDomain is string (uppercase error)", async () => {
+  const stack = new Stack(new App(), "stack");
+  expect(() => {
+    new Api(stack, "Api", {
+      customDomain: "API.domain.com",
+    });
+  }).toThrow(/The domain name needs to be in lowercase/);
+});
 
 test("constructor: customDomain is string (imported ssm)", async () => {
   const stack = new Stack(new App(), "stack");
@@ -437,16 +437,16 @@ test("constructor: customDomain.domainName is string", async () => {
   });
 });
 
-// test("constructor: customDomain.domainName is string (uppercase error)", async () => {
-//   const stack = new Stack(new App(), "stack");
-//   expect(() => {
-//     new Api(stack, "Api", {
-//       customDomain: {
-//         domainName: "API.domain.com",
-//       },
-//     });
-//   }).toThrow(/The domain name needs to be in lowercase/);
-// });
+test("constructor: customDomain.domainName is string (uppercase error)", async () => {
+  const stack = new Stack(new App(), "stack");
+  expect(() => {
+    new Api(stack, "Api", {
+      customDomain: {
+        domainName: "API.domain.com",
+      },
+    });
+  }).toThrow(/The domain name needs to be in lowercase/);
+});
 
 test("constructor: customDomain.domainName is string (imported ssm), hostedZone undefined", async () => {
   const stack = new Stack(new App(), "stack");
@@ -488,10 +488,6 @@ test("customDomain: isExternalDomain true", async () => {
           EndpointType: "REGIONAL",
         },
       ],
-      Tags: {
-        "sst:app": "my-app",
-        "sst:stage": "dev",
-      },
     })
   );
 });

--- a/packages/resources/test/Api.test.ts
+++ b/packages/resources/test/Api.test.ts
@@ -473,7 +473,6 @@ test("customDomain: isExternalDomain true", async () => {
       isExternalDomain: true,
     },
   });
-  console.log(stack);
   expect(site.customDomainUrl).toEqual("https://www.domain.com");
   expectCdk(stack).to(
     haveResource("AWS::ApiGatewayV2::Api", {

--- a/www/docs/constructs/Api.md
+++ b/www/docs/constructs/Api.md
@@ -406,6 +406,25 @@ new Api(this, "Api", {
 
 Note that, normally SST will look for a hosted zone by stripping out the first part of the `domainName`. But this is not possible when the `domainName` is a reference. Since its value will be resolved at deploy time. So you'll need to specify the `hostedZone` explicitly.
 
+#### Using externally hosted domain
+
+```js {4-8}
+import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
+
+new Api(this, "Api", {
+  customDomain: {
+    isExternalDomain: true,
+    domainName: "api.domain.com",
+    certificate: Certificate.fromCertificateArn(this, "MyCert", certArn),
+  },
+  routes: {
+    "GET /notes": "src/list.main",
+  },
+});
+```
+
+Note that you can also migrate externally hosted domains to Route 53 by [following this guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
+
 ### Attaching permissions
 
 You can attach a set of permissions to all or some of the routes.

--- a/www/docs/constructs/StaticSite.md
+++ b/www/docs/constructs/StaticSite.md
@@ -197,7 +197,7 @@ There are a couple of things happening behind the scenes here:
 
 :::
 
-### Configuring custom domains hosted on Route 53
+### Configuring custom domains
 
 You can configure the website with a custom domain hosted either on [Route 53](https://aws.amazon.com/route53/) or [externally](#configuring-externally-hosted-domain).
 
@@ -291,7 +291,7 @@ new StaticSite(this, "Site", {
 
 #### Configuring externally hosted domain
 
-```js {5-8}
+```js {5-9}
 import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 
 new StaticSite(this, "Site", {

--- a/www/docs/constructs/WebSocketApi.md
+++ b/www/docs/constructs/WebSocketApi.md
@@ -266,6 +266,25 @@ new WebSocketApi(this, "Api", {
 });
 ```
 
+#### Using externally hosted domain
+
+```js {4-8}
+import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
+
+new WebSocketApi(this, "Api", {
+  customDomain: {
+    isExternalDomain: true,
+    domainName: "api.domain.com",
+    certificate: Certificate.fromCertificateArn(this, "MyCert", certArn),
+  },
+  routes: {
+    $default: "src/default.main",
+  },
+});
+```
+
+Note that you can also migrate externally hosted domains to Route 53 by [following this guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
+
 ### Attaching permissions
 
 You can attach a set of permissions to all or some of the routes.


### PR DESCRIPTION
Added support for adding custom domains to the `Api` construct that are outside of Route 53. 

Sample code example:

```ts
const api = new sst.Api(this, "Api", {
  customDomain: {
    domainName: "api.sst.sh",
    isExternalDomain: true,
    certificate: acm.Certificate.fromCertificateArn(
      this,
      "Certificate",
      "arn:aws:acm:us-east-1:000639264671:certificate/xxxx"
    ),
  },
  routes: {
    "GET /": "src/lambda.main",
  },
});
```