### PR TITLE
Update tempalte to avoid conflicts with NextJS

### DIFF
--- a/packages/create-serverless-stack/templates/typescript/.template.gitignore
+++ b/packages/create-serverless-stack/templates/typescript/.template.gitignore
@@ -10,8 +10,8 @@
 /build
 
 # typescript
-*.js
-*.d.ts
+/*.js
+/*.d.ts
 
 # misc
 .DS_Store


### PR DESCRIPTION
I run `npx create-serverless-stack@latest my-sst-app --language typescript` to create a new project using Typescript. In this project I'm also developing NextJS in a `/frontend` folder. After hitting some issues during CI/CD I realised that this template was causing git to ignore of .config.js files in the `/fronted` folder.