### PR TITLE
Display last update time on docs

### DIFF
--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -142,6 +142,7 @@ module.exports = {
           routeBasePath: "/",
           sidebarCollapsible: false,
           sidebarPath: require.resolve("./sidebars.js"),
+          showLastUpdateTime: true,
           // Please change this to your repo.
           editUrl:
             "https://github.com/serverless-stack/serverless-stack/edit/master/www/",


### PR DESCRIPTION
Now we'll get something like this _(without author's name)_:

![image](https://user-images.githubusercontent.com/13461315/147515798-3da3efb8-0323-4e89-834f-6b7402330ddc.png)

so we can easily see if the docs has been updated since the last time :)

I didn't tested this locally, but I've followed this guide: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs