### PR TITLE
static-site-env: remove unused and add missing dependencies

### DIFF
--- a/packages/static-site-env/package.json
+++ b/packages/static-site-env/package.json
@@ -23,9 +23,9 @@
   },
   "homepage": "https://serverless-stack.com",
   "dependencies": {
-    "@serverless-stack/core": "^0.65.1",
-    "chalk": "^4.1.0",
-    "yargs": "^15.4.1"
+    "cross-spawn": "^7.0.3",
+    "fs-extra": "^9.0.1",
+    "minimist": "^1.2.5"
   },
   "devDependencies": {
     "jest": "^26.1.0"


### PR DESCRIPTION
Adding @serverless-stack/static-site-env to a project will result in more than 450 dependencies being installed in node_modules.

```
{
  "name": "test",
  "version": "0.1.0",
  "private": true,
  "devDependencies": {
    "@serverless-stack/static-site-env": "0.61.2"
  }
}
```

This is due to a dependency on @serverless-stack/core from which no functionality is actually used. This PR removes the @serverless-stack/core dependency and a few others and replacing them with the dependencies that are actually required by the script itself. This will keep the number of transitive dependencies to a bare minimum.
