### PR TITLE
Prevent loading jsdom, which mocks fetch/XHR

### DIFF
--- a/packages/cli/scripts/util/createJestConfig.js
+++ b/packages/cli/scripts/util/createJestConfig.js
@@ -11,6 +11,7 @@ const paths = require("./paths");
 module.exports = (resolve, rootDir) => {
   const config = {
     collectCoverageFrom: ["./**/*.{js,jsx,ts,tsx}"],
+    testEnvironment: "node",
     testMatch: [
       "<rootDir>/**/__tests__/**/*.{js,jsx,ts,tsx}",
       "<rootDir>/**/*.{spec,test}.{js,jsx,ts,tsx}",


### PR DESCRIPTION
In a test I'm using a library that uses Axios, this _should_ be fine... but

somehow I get an error indicating that a `OPTIONS` request gets a 405 error. This is curious, as this library should not do a OPTIONS request. After viewing the stacktrace, it became apparent that jsdom had stubbed the nodejs-native request functionality, tricking Axios in using that. This is insane, that in a SST app jsdom is loaded (a React utility).

So this PR sets the testEnvironment to `node` to prevent loading jsdom.