### PR TITLE
sst start: add trace to Python bootstrap.py error reporting

### DIFF
--- a/packages/core/src/runtime/shells/bootstrap.py
+++ b/packages/core/src/runtime/shells/bootstrap.py
@@ -85,6 +85,7 @@ if __name__ == '__main__':
         result = {
             "errorType": ex_type.__name__,
             "errorMessage": str(ex_value),
+            "trace": traceback.format_tb(ex_traceback),
         }
 
     # send response


### PR DESCRIPTION
This prevents crashing the live dev lambda handler. Fixes the issue discussed in Slack: https://serverless-stack.slack.com/archives/C01JG3B20RY/p1645525472903309