### PR TITLE
Add `cdk.context.json`  to .gitignore template

### DIFF
--- a/packages/create-serverless-stack/templates/javascript/.template.gitignore
+++ b/packages/create-serverless-stack/templates/javascript/.template.gitignore
@@ -16,6 +16,9 @@
 .build
 .sst
 
+# CDK Context
+cdk.context.json
+
 # environments
 .env*.local
 


### PR DESCRIPTION
The file was generated when specifying `customDomain`.  There are other CDK related files, dunno if they should be added as well:
https://github.com/aws/aws-cdk/blob/5bad3aaac6cc7cc7befb8bdd320181a7c650f15d/.gitignore#L32-L36