### PR TITLE
sst-env: fix cannot find environment when custom stack names are used

### DIFF
--- a/packages/cli/scripts/start.js
+++ b/packages/cli/scripts/start.js
@@ -575,7 +575,7 @@ async function updateStaticSiteEnvironmentOutputs(deployRet) {
   // Replace output value with stack output
   const environments = await fs.readJson(environmentOutputKeysPath);
   environments.forEach(({ stack, environmentOutputs }) => {
-    const stackData = deployRet.find(({ name }) => name === stack);
+    const stackData = deployRet.find(({ id }) => id === stack);
     if (stackData) {
       Object.entries(environmentOutputs).forEach(([envName, outputName]) => {
         environmentOutputs[envName] = stackData.outputs[outputName];

--- a/packages/cli/scripts/util/cdkHelpers.js
+++ b/packages/cli/scripts/util/cdkHelpers.js
@@ -366,6 +366,7 @@ async function deploy(cdkOptions, stackName) {
   await printDeployResults(stackStates, cdkOptions);
 
   return stackStates.map((stackState) => ({
+    id: stackState.id,
     name: stackState.name,
     status: stackState.status,
     errorMessage: stackState.errorMessage,


### PR DESCRIPTION
Resolves https://github.com/serverless-stack/serverless-stack/issues/1565

This change updates the search for matching stack outputs to be based on the stack id rather than name which should be stable (?)