### PR TITLE
CLI: add support for SSO and --profile option

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
     "async-retry": "^1.3.3",
     "aws-cdk": "2.15.0",
     "aws-cdk-lib": "2.15.0",
-    "aws-sdk": "2.1095.0",
+    "aws-sdk": "^2.1095.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.5.2",
     "ci-info": "^3.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
     "async-retry": "^1.3.3",
     "aws-cdk": "2.15.0",
     "aws-cdk-lib": "2.15.0",
-    "aws-sdk": "^2.761.0",
+    "aws-sdk": "2.1095.0",
     "chalk": "^4.1.0",
     "chokidar": "^3.5.2",
     "ci-info": "^3.3.0",

--- a/packages/core/src/aws-sdk/index.ts
+++ b/packages/core/src/aws-sdk/index.ts
@@ -3,10 +3,17 @@ import aws from "aws-sdk";
 
 let credentials: aws.Credentials;
 
-export async function getAwsCredentials() {
+export interface AwsCredentialsOptions {
+  /**
+   * The AWS Credentials profile to force.
+   */
+  readonly profile: string;
+}
+
+export async function getAwsCredentials(options?: AwsCredentialsOptions) {
   if (!credentials) {
     const chain = await AwsCliCompatible.credentialChain({
-      //profile: options.profile,
+      profile: options?.profile,
       //ec2instance: options.ec2creds,
       //containerCreds: options.containerCreds,
       //httpOptions: sdkOptions.httpOptions,

--- a/www/docs/packages/cli.md
+++ b/www/docs/packages/cli.md
@@ -193,7 +193,7 @@ npx sst console --stage=staging
 Using a different aws profile if your stage is in another AWS account.
 
 ```bash
-AWS_PROFILE=acme-production npx sst console --stage=production
+npx sst console --stage=production --profile=acme-production
 ```
 
 ### `remove [stack]`
@@ -306,21 +306,31 @@ The region you want to deploy to. Defaults to the one specified in your `sst.jso
 The `--stage` and `--region` options apply to the `start`, `build`, `deploy`, and `remove` commands.
 :::
 
+### `--profile`
+
+The AWS profile you want to use for deployment. Defaults to the `default` profile in your AWS credentials file.
+
 ### `--role-arn`
 
-ARN of the IAM Role to use when invoking CloudFormation. If not specified, the default AWS profile, or the profile specified in the `AWS_PROFILE` environment variable will be used.
+ARN of the IAM Role to use when invoking CloudFormation. This role must be assumable by the AWS account being used.
 
 This option applies to the `start`, `deploy`, and `remove` commands.
 
 ## AWS Profile
 
-Specify the AWS account you want to deploy to by using the `AWS_PROFILE` CLI environment variable. If not specified, uses the default AWS profile. [Read more about AWS profiles here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html). For example:
+Specify the AWS account you want to deploy to by using the `--profile` option. If not specified, uses the default AWS profile. [Read more about AWS profiles here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html). For example:
+
+```bash
+npx sst deploy --profile=production
+```
+
+Where `production` is a profile defined locally in your `~/.aws/credentials`.
+
+Or, use the `AWS_PROFILE` CLI environment variable
 
 ```bash
 AWS_PROFILE=production npx sst deploy
 ```
-
-Where `production` is a profile defined locally in your `~/.aws/credentials`.
 
 ## Package scripts
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6423,6 +6423,21 @@ aws-jwt-verify@^2.1.3:
   resolved "https://registry.yarnpkg.com/aws-jwt-verify/-/aws-jwt-verify-2.1.3.tgz#54643f744a9913e005917b39aed5cae55272ae4f"
   integrity sha512-XAlt1IaQg9SRpuKPAhW1I1/E9Q63bPI/O+W5dcGniDwTJSbAUVZsH80XxeuADBCD2eIWEUlKOFfLmzhXZqt9tA==
 
+aws-sdk@2.1095.0:
+  version "2.1095.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1095.0.tgz#7847493b09a326a0613010ed9db53302f760edf6"
+  integrity sha512-OrZq2pTDsnfOJYsAdRlw+NXTGLQYqWldSZR3HugW8JT4JPWyFZrgB2yPP2ElFHX+4J4SZg5QvkAXl/7s9gLTgA==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sdk@^2.1061.0, aws-sdk@^2.761.0:
   version "2.1072.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1072.0.tgz#4fa844765ebb65b78c242b8edcf98a1669d4523b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6423,10 +6423,10 @@ aws-jwt-verify@^2.1.3:
   resolved "https://registry.yarnpkg.com/aws-jwt-verify/-/aws-jwt-verify-2.1.3.tgz#54643f744a9913e005917b39aed5cae55272ae4f"
   integrity sha512-XAlt1IaQg9SRpuKPAhW1I1/E9Q63bPI/O+W5dcGniDwTJSbAUVZsH80XxeuADBCD2eIWEUlKOFfLmzhXZqt9tA==
 
-aws-sdk@2.1095.0:
-  version "2.1095.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1095.0.tgz#7847493b09a326a0613010ed9db53302f760edf6"
-  integrity sha512-OrZq2pTDsnfOJYsAdRlw+NXTGLQYqWldSZR3HugW8JT4JPWyFZrgB2yPP2ElFHX+4J4SZg5QvkAXl/7s9gLTgA==
+aws-sdk@^2.1061.0, aws-sdk@^2.761.0:
+  version "2.1072.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1072.0.tgz#4fa844765ebb65b78c242b8edcf98a1669d4523b"
+  integrity sha512-b0gEHuC6xTGduPTS+ZCScurw9RTyOned9gf6H0rDagW8hdSMebsFQy84ZreeiZHHChyKyWrNUbUFugOYdw+WXw==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -6438,10 +6438,10 @@ aws-sdk@2.1095.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
-aws-sdk@^2.1061.0, aws-sdk@^2.761.0:
-  version "2.1072.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1072.0.tgz#4fa844765ebb65b78c242b8edcf98a1669d4523b"
-  integrity sha512-b0gEHuC6xTGduPTS+ZCScurw9RTyOned9gf6H0rDagW8hdSMebsFQy84ZreeiZHHChyKyWrNUbUFugOYdw+WXw==
+aws-sdk@^2.1095.0:
+  version "2.1099.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1099.0.tgz#3bf9a1d3352895548cc3bf6513bae74ee03a1e6c"
+  integrity sha512-7pWBLU4q/obqkV+Vw6RrcRA2QJXX2i+CQ+OB88AtxoymvIq/vSGgJ72SrQDvzn1Bu1zIZKtTA+PTJkMQiLAh1w==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
Mirrors the CDK's changes in https://github.com/aws/aws-cdk/pull/19454 to support SSO.

While I was in this section, added missing support for the `--profile` parameter.

There was a lot of whitespace changes that I think kicked in because of prettier/linting. Relevant changes (aside from CLI) exactly mirror the pull request linked above.

Closes https://github.com/serverless-stack/serverless-stack/issues/1552;