### PR TITLE
enhancement: allow `this` in `stack`

### DIFF
--- a/packages/resources/src/FunctionalStack.ts
+++ b/packages/resources/src/FunctionalStack.ts
@@ -20,7 +20,7 @@ export function stack(
     app,
     stack,
   };
-  const returns = fn(ctx);
+  const returns = fn.bind(stack)(ctx);
   if (returns && "then" in returns)
     return returns.then((data: any) => {
       getExports(app).set(fn, data);
@@ -54,7 +54,7 @@ export type StackContext = {
   stack: Stack;
 };
 
-export type FunctionalStack<T> = (ctx: StackContext) => T | Promise<T>;
+export type FunctionalStack<T> = (this: Stack, ctx: StackContext) => T | Promise<T>;
 
 class EmptyStack extends Stack {
   constructor(scope: App, id: string, props?: StackProps) {


### PR DESCRIPTION
Adds a small change to bind `this` in `stack` usage allowing idiomatic `new Resource(this, 'Id', {})` usage of CDK resources.

(example stolen from graphql)
```typescript
import { App, Stack, StackContext, RDS } from "@serverless-stack/resources";

export default async function main(app: App) {
  app.setDefaultFunctionProps({
    runtime: "nodejs14.x",
    srcPath: "backend",
    environment: {
      SSM_PREFIX: `/${app.name}/${app.stage}/`,
      SSM_FALLBACK: `/${app.name}/fallback/`,
    },
  });
  if (app.local) app.setDefaultRemovalPolicy(RemovalPolicy.DESTROY);

  app
    .stack(Database);
}

export function Database(this: Stack, ctx: StackContext) {
  const cluster = new RDS(this, "RDS", {
    engine: "postgresql10.14",
    defaultDatabaseName: "starter",
    migrations: "./migrations",
  });

  return cluster;
}
```