### PR TITLE
Use ExpressionAttributeNames instead of the key directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ cdk.out
 .DS_Store
 yarn.lock
 yarn.lock
+
+# Jetbrains
+.idea

--- a/packages/console/src/data/aws/dynamodb.ts
+++ b/packages/console/src/data/aws/dynamodb.ts
@@ -67,7 +67,7 @@ export function useScanTable(name?: string, index?: string, opts?: ScanOpts) {
         .filter(
           (item) => !isQuery || ![opts.pk?.key, opts.sk?.key].includes(item.key)
         )
-        .map((item) => `${item.key} ${item.op} :${item.key}`);
+        .map((item) => `#${item.key} ${item.op} :${item.key}`);
 
       const expressionAttributes = [opts.pk, opts.sk, ...opts.filters]
         .filter((item) => Boolean(item?.op))
@@ -84,6 +84,9 @@ export function useScanTable(name?: string, index?: string, opts?: ScanOpts) {
           ];
         });
 
+      const expressionAttributesNames = [opts.pk, opts.sk, ...opts.filters]
+        .filter((item) => Boolean(item?.op))
+        .map((item) => [`#${item.key}`, item.key]);
       const params: ScanCommandInput = {
         TableName: name,
         IndexName: index === "Primary" ? undefined : index,
@@ -91,6 +94,9 @@ export function useScanTable(name?: string, index?: string, opts?: ScanOpts) {
         Limit: 50,
         FilterExpression: filterExpression.length
           ? filterExpression.join(" AND ")
+          : undefined,
+        ExpressionAttributeNames: expressionAttributesNames.length
+          ? Object.fromEntries(expressionAttributesNames)
           : undefined,
         ExpressionAttributeValues: expressionAttributes.length
           ? Object.fromEntries(expressionAttributes)


### PR DESCRIPTION
Currently using special column names like `_type` does not work in the console, this PR should fix that.