### PR TITLE
[Console]: Random bracket in Console UI

### DIFF
--- a/packages/console/src/App/Stage/Stacks/index.tsx
+++ b/packages/console/src/App/Stage/Stacks/index.tsx
@@ -139,7 +139,6 @@ export function Stacks() {
           </StackItem>
         ))}
       </Content>
-      )
     </>
   );
 }


### PR DESCRIPTION
Hey, saw this random bracket on the bottom left of the console stack page, which looks like it's from a typo