### PR TITLE
NextJSSite: Added CloudFront Origin Req Policy override

### DIFF
--- a/packages/resources/test/NextjsSite.test.ts
+++ b/packages/resources/test/NextjsSite.test.ts
@@ -822,6 +822,41 @@ test("constructor: cfCachePolicies props override", async () => {
   countResources(stack, "AWS::CloudFront::CachePolicy", 0);
 });
 
+test("constructor: cfImageOriginRequestPolicy props default", async () => {
+  const stack = new Stack(new App(), "stack");
+  new NextjsSite(stack, "Site", {
+    path: "test/nextjs-site",
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore: "jestBuildOutputPath" not exposed in props
+    jestBuildOutputPath: buildOutputPath,
+  });
+  countResources(stack, "AWS::CloudFront::OriginRequestPolicy", 1);
+  hasResource(stack, "AWS::CloudFront::OriginRequestPolicy", {
+    OriginRequestPolicyConfig: objectLike({
+      Comment: "SST NextjsSite Lambda Default Origin Request Policy",
+    }),
+  });
+});
+
+test("constructor: cfImageOriginRequestPolicy props override", async () => {
+  const stack = new Stack(new App(), "stack");
+  new NextjsSite(stack, "Site", {
+    path: "test/nextjs-site",
+    cdk: {
+      imageOriginRequestPolicy:
+        cf.OriginRequestPolicy.fromOriginRequestPolicyId(
+          stack,
+          "ImageOriginRequestPolicy",
+          "imageOriginRequestPolicyId"
+        ),
+    },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore: "jestBuildOutputPath" not exposed in props
+    jestBuildOutputPath: buildOutputPath,
+  });
+  countResources(stack, "AWS::CloudFront::OriginRequestPolicy", 0);
+});
+
 test("constructor: cfDistribution props", async () => {
   const stack = new Stack(new App(), "stack");
   new NextjsSite(stack, "Site", {

--- a/www/docs/constructs/NextjsSite.md
+++ b/www/docs/constructs/NextjsSite.md
@@ -312,6 +312,30 @@ new NextjsSite(this, "Site2", {
 });
 ```
 
+#### Reusing CloudFront origin request policies
+
+Similar to the cache policies mentioned above, CloudFront has a limit of 20 origin request policies per AWS account. This is a hard limit, and cannot be increased. When using `next/image`, each `NextjsSite` creates a new origin request policy by default. If you plan to deploy multiple Next.js sites, you can have the constructs share the same origin request policy by reusing them across sites.
+
+```js
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+
+const imageOriginRequestPolicy = new cloudfront.OriginRequestPolicy(stack, "ImageOriginRequest", NextjsSite.imageOriginRequestPolicyProps);
+
+new NextjsSite(this, "Site1", {
+  path: "path/to/site1",
+  cdk: {
+    imageOriginRequestPolicy,
+  }
+});
+
+new NextjsSite(this, "Site2", {
+  path: "path/to/site2",
+  cdk: {
+    imageOriginRequestPolicy,
+  }
+});
+```
+
 ## NextjsSiteProps
 
 
@@ -431,33 +455,15 @@ _Type_ : <span class="mono">[ICachePolicy](https://docs.aws.amazon.com/cdk/api/v
 
 _Type_ : <span class="mono">[ICachePolicy](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudfront.ICachePolicy.html)</span>
 
-
 Override the default CloudFront cache policies created internally.
 
 
-### Reusng CloudFront cache policies
+### cdk.imageOriginRequestPolicy?
 
-CloudFront has a limit of 20 cache policies per AWS account. This is a hard limit, and cannot be increased. Each `NextjsSite` creates 3 cache policies. If you plan to deploy multiple Next.js sites, you can have the constructs share the same cache policies by reusing them across sites.
+_Type_ : <span class="mono">[IOriginRequestPolicy](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudfront.IOriginRequestPolicy.html)</span>
 
-```js
-import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+Override the default CloudFront origin request policy created internally.
 
-const cachePolicies = {
-  staticCachePolicy: new NextjsSite(stack, "StaticCache", NextjsSite.staticCachePolicyProps),
-  imageCachePolicy: new NextjsSite(stack, "ImageCache", NextjsSite.imageCachePolicyProps),
-  lambdaCachePolicy: new NextjsSite(stack, "LambdaCache", NextjsSite.lambdaCachePolicyProps),
-};
-
-new NextjsSite(stack, "Site1", {
-  path: "path/to/site1",
-  cfCachePolicies: cachePolicies,
-});
-
-new NextjsSite(stack, "Site2", {
-  path: "path/to/site2",
-  cfCachePolicies: cachePolicies,
-});
-```
 
 ### cdk.distribution?
 
@@ -471,9 +477,10 @@ _Type_ : <span class="mono">[QueueProps](https://docs.aws.amazon.com/cdk/api/v2/
 
 Override the default settings this construct uses to create the CDK `Queue` internally.
 
-
 ## Properties
+
 An instance of `NextjsSite` has the following properties.
+
 ### bucketArn
 
 _Type_ : <span class="mono">string</span>


### PR DESCRIPTION
As mentioned in #1531, there is a hard limit of 20 Origin Request Policies on a single AWS account. This causes rate limits when several branches are being deployed at once as when using `next/image`, the NextJSSite constructor creates a new one for each PR.

This fixes #1531 by adding a custom override property (`imageOriginRequestPolicy`) to the NextJSSite constructor. Now users can share AWS Request Origin Policies across stacks.