### PR TITLE
Fix simple lambda authorizer example

### DIFF
--- a/.changeset/wicked-pianos-vanish.md
+++ b/.changeset/wicked-pianos-vanish.md
@@ -1,0 +1,5 @@
+---
+"create-sst": patch
+---
+
+Example: fix responseType in simple Lambda authorizer example

--- a/examples/api-auth-lambda-authorizer-simple-response/stacks/MyStack.ts
+++ b/examples/api-auth-lambda-authorizer-simple-response/stacks/MyStack.ts
@@ -6,6 +6,7 @@ export function MyStack({ stack }: StackContext) {
     authorizers: {
       lambda: {
         type: "lambda",
+        responseTypes: ['simple'],
         function: new Function(stack, "Authorizer", {
           handler: "functions/authorizer.main",
         }),

--- a/packages/create-sst/bin/presets/examples/api-auth-lambda-authorizer-simple-response/templates/stacks/MyStack.ts
+++ b/packages/create-sst/bin/presets/examples/api-auth-lambda-authorizer-simple-response/templates/stacks/MyStack.ts
@@ -6,6 +6,7 @@ export function MyStack({ stack }: StackContext) {
     authorizers: {
       lambda: {
         type: "lambda",
+        responseTypes: ["simple"],
         function: new Function(stack, "Authorizer", {
           handler: "functions/authorizer.main",
         }),


### PR DESCRIPTION
Add `responseTypes: ['simple']` which was missing to the `api-auth-lambda-authorizer-simple-response` example