### PR TITLE
console: fix dynamodb scan KeyConditionExpression

### DIFF
--- a/packages/console/src/data/aws/dynamodb.ts
+++ b/packages/console/src/data/aws/dynamodb.ts
@@ -110,7 +110,7 @@ export function useScanTable(name?: string, index?: string, opts?: ScanOpts) {
               KeyConditionExpression: (["pk", "sk"] as const)
                 .map((key) => opts[key])
                 .filter((item) => Boolean(item?.op))
-                .map((item) => `${item.key} ${item.op} :${item.key}`)
+                .map((item) => `#${item.key} ${item.op} :${item.key}`)
                 .join(" AND "),
             })
           : new ScanCommand(params)


### PR DESCRIPTION
Relates to [this thread](https://serverless-stack.slack.com/archives/C01JG3B20RY/p1653026414646839)

A scan with filters in the Console DynamoDB view do not succeed because the `KeyConditionExpression` keys are not prefixed with `#`

![image](https://user-images.githubusercontent.com/21118015/169690771-865c0414-b743-4a62-b3b2-7c0736e28f8a.png)
![image](https://user-images.githubusercontent.com/21118015/169690753-2cb4db14-afec-4c37-b718-8e7a38e6e2d9.png)
![image](https://user-images.githubusercontent.com/21118015/169690761-f9b40e8c-a083-4e04-a96b-d9942effb652.png)
