### PR TITLE
bug: golang configuration needed on M1 Mac

### DIFF
--- a/.changeset/smart-peaches-check.md
+++ b/.changeset/smart-peaches-check.md
@@ -1,0 +1,5 @@
+---
+"@serverless-stack/core": patch
+---
+
+Golang: set GOARCH when building on M1 Mac

--- a/.changeset/smart-peaches-check.md
+++ b/.changeset/smart-peaches-check.md
@@ -2,4 +2,4 @@
 "@serverless-stack/core": patch
 ---
 
-Golang: set GOARCH when building on M1 Mac
+Golang: set GOARCH when bundling for `sst deploy`

--- a/packages/core/src/runtime/handler/go.ts
+++ b/packages/core/src/runtime/handler/go.ts
@@ -14,7 +14,10 @@ export const GoHandler: Definition = (opts) => {
   const build: Command = {
     command: "go",
     args: ["build", "-ldflags", "-s -w", "-o", target, "./" + opts.handler],
-    env: {},
+    env: {
+      GOARCH: 'amd64',
+      GOOS:'linux'
+    },
   };
   return {
     build: () => {

--- a/packages/core/src/runtime/handler/go.ts
+++ b/packages/core/src/runtime/handler/go.ts
@@ -14,10 +14,7 @@ export const GoHandler: Definition = (opts) => {
   const build: Command = {
     command: "go",
     args: ["build", "-ldflags", "-s -w", "-o", target, "./" + opts.handler],
-    env: {
-      GOARCH: 'amd64',
-      GOOS:'linux'
-    },
+    env: {},
   };
   return {
     build: () => {
@@ -32,6 +29,7 @@ export const GoHandler: Definition = (opts) => {
         ...build,
         env: {
           CGO_ENABLED: "0",
+          GOARCH: "amd64",
           GOOS: "linux",
         },
       });


### PR DESCRIPTION
To support real Zero-Config for golang on M1 Mac  these environment variables have to be set. Otherwise go will use the current systems architecture which is ARM instead of AMD64 on an M1 Mac.

Currently there is only one supported golang runtime (go1.x) which only has amd64 Processors. But after #1271 there will be the possibility to use ARM runtimes. So #1271 should change this to include logic based on real architecture. Not needed for now.

This fixes issue #1757