### PR TITLE
Allow custom CDK hostedZone for sst.Api customDomain

### DIFF
--- a/.changeset/young-deers-eat.md
+++ b/.changeset/young-deers-eat.md
@@ -1,0 +1,5 @@
+---
+"@serverless-stack/resources": patch
+---
+
+Api: allow cdk.hostedZone when domainName is token value

--- a/packages/resources/src/ApiGatewayV1Api.ts
+++ b/packages/resources/src/ApiGatewayV1Api.ts
@@ -935,7 +935,7 @@ export class ApiGatewayV1Api<
       if (cdk.Token.isUnresolved(customDomain.domainName)) {
         // If customDomain is a TOKEN string, "hostedZone" has to be passed in. This
         // is because "hostedZone" cannot be parsed from a TOKEN value.
-        if (!customDomain.hostedZone) {
+        if (!customDomain.hostedZone && !customDomain.cdk?.hostedZone) {
           throw new Error(
             `You also need to specify the "hostedZone" if the "domainName" is passed in as a reference.`
           );

--- a/packages/resources/src/util/apiGatewayV2Domain.ts
+++ b/packages/resources/src/util/apiGatewayV2Domain.ts
@@ -111,7 +111,7 @@ function buildDataForInternalDomainInput(
   // If customDomain is a TOKEN string, "hostedZone" has to be passed in. This
   // is because "hostedZone" cannot be parsed from a TOKEN value.
   if (cdk.Token.isUnresolved(customDomain.domainName)) {
-    if (!customDomain.hostedZone && !customDomain.cdk.hostedZone) {
+    if (!customDomain.hostedZone && !customDomain.cdk?.hostedZone) {
       throw new Error(
         `You also need to specify the "hostedZone" if the "domainName" is passed in as a reference.`
       );

--- a/packages/resources/src/util/apiGatewayV2Domain.ts
+++ b/packages/resources/src/util/apiGatewayV2Domain.ts
@@ -111,7 +111,7 @@ function buildDataForInternalDomainInput(
   // If customDomain is a TOKEN string, "hostedZone" has to be passed in. This
   // is because "hostedZone" cannot be parsed from a TOKEN value.
   if (cdk.Token.isUnresolved(customDomain.domainName)) {
-    if (!customDomain.hostedZone) {
+    if (!customDomain.hostedZone && !customDomain.cdk.hostedZone) {
       throw new Error(
         `You also need to specify the "hostedZone" if the "domainName" is passed in as a reference.`
       );


### PR DESCRIPTION
Use the sst.Api customDomain.cdk.hostedZone property when the customDomain.hostedZone is not set

Refer to https://github.com/serverless-stack/serverless-stack/issues/1771