### PR TITLE
Fix ApiGatewayV1Api looking up hosted zone when provided

### DIFF
--- a/packages/resources/src/ApiGatewayV1Api.ts
+++ b/packages/resources/src/ApiGatewayV1Api.ts
@@ -947,12 +947,17 @@ export class ApiGatewayV1Api<
       }
 
       // parse customDomain.hostedZone
-      if (!customDomain.hostedZone) {
+      if (customDomain.hostedZone && customDomain.cdk?.hostedZone) {
+        throw new Error(
+          `Cannot configure "hostedZone" when the "cdk.hostedZone" is provided`
+        );
+      }
+      if (customDomain.cdk?.hostedZone) {
+        hostedZone = customDomain.cdk?.hostedZone;
+      } else if (!customDomain.hostedZone) {
         hostedZoneDomain = domainName.split(".").slice(1).join(".");
       } else if (typeof customDomain.hostedZone === "string") {
         hostedZoneDomain = customDomain.hostedZone;
-      } else {
-        hostedZone = customDomain.hostedZone;
       }
 
       certificate = customDomain.cdk?.certificate;

--- a/packages/resources/test/ApiGatewayV1Api.test.ts
+++ b/packages/resources/test/ApiGatewayV1Api.test.ts
@@ -605,6 +605,23 @@ test("customDomain: internal domain: domainName is string, cdk.hostedZone define
   });
 });
 
+test("customDomain: internal domain: domainName is string, hostedZone is string, cdk.hostedZone defined", async () => {
+  const stack = new Stack(new App({ name: "apiv1" }), "stack");
+  expect(() => {
+    new ApiGatewayV1Api(stack, "Api", {
+      customDomain: {
+        domainName: "api.domain.com",
+        hostedZone: 'domain.com',
+        cdk: {
+          hostedZone: new route53.HostedZone(stack, "Zone", {
+            zoneName: "domain.com",
+          }),
+        }
+      },
+    });
+  }).toThrow(/Cannot configure "hostedZone" when the "cdk\.hostedZone" is provided/);
+});
+
 test("customDomain: internal domain: domainName is string (imported ssm), hostedZone undefined", async () => {
   const stack = new Stack(new App({ name: "apiv1" }), "stack");
   const domain = ssm.StringParameter.valueForStringParameter(stack, "domain");

--- a/packages/resources/test/ApiGatewayV1Api.test.ts
+++ b/packages/resources/test/ApiGatewayV1Api.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, vi } from "vitest";
+import { test, expect, vi, beforeEach } from "vitest";
 import {
   ANY,
   ABSENT,
@@ -20,6 +20,12 @@ const lambdaDefaultPolicy = {
   Effect: "Allow",
   Resource: "*",
 };
+
+const actualHostedZoneFromLookup = route53.HostedZone.fromLookup;
+
+beforeEach(() => {
+  route53.HostedZone.fromLookup = actualHostedZoneFromLookup;
+})
 
 ///////////////////
 // Test Constructor
@@ -488,6 +494,11 @@ test("customDomain: internal domain: domainName is string (uppercase error)", as
 test("customDomain: internal domain: domainName is string (imported ssm), hostedZone defined", async () => {
   const stack = new Stack(new App({ name: "apiv1" }), "stack");
   const domain = ssm.StringParameter.valueForStringParameter(stack, "domain");
+  route53.HostedZone.fromLookup = vi
+    .fn()
+    .mockImplementation((scope, id, { domainName }) => {
+      return new route53.HostedZone(scope, id, { zoneName: domainName });
+    });
   new ApiGatewayV1Api(stack, "Api", {
     customDomain: {
       domainName: domain,
@@ -548,6 +559,49 @@ test("customDomain: internal domain: domainName is string (imported ssm), cdk.ho
       Ref: ANY,
     },
     Type: "A",
+  });
+});
+
+test("customDomain: internal domain: domainName is string, cdk.hostedZone defined", async () => {
+  const stack = new Stack(new App({ name: "apiv1" }), "stack");
+  route53.HostedZone.fromLookup = vi
+    .fn()
+    .mockImplementation(() => {
+      // If cdk.hostedZone is provided that should be used and no lookup should be required
+      throw new Error('No hosted zone should be looked up');
+    });
+  new ApiGatewayV1Api(stack, "Api", {
+    customDomain: {
+      domainName: 'api.domain.com',
+      cdk: {
+        hostedZone: new route53.HostedZone(stack, "Zone", {
+          zoneName: "domain.com",
+        }),
+      }
+    },
+  });
+
+  hasResource(stack, "AWS::ApiGateway::RestApi", {
+    Name: "dev-apiv1-Api",
+  });
+  hasResource(stack, "AWS::ApiGateway::DomainName", {
+    DomainName: "api.domain.com",
+    EndpointConfiguration: { Types: ["REGIONAL"] },
+    RegionalCertificateArn: { Ref: "ApiCertificate285C31EB" },
+  });
+  hasResource(stack, "AWS::CertificateManager::Certificate", {
+    DomainName: "api.domain.com",
+  });
+  hasResource(stack, "AWS::Route53::RecordSet", {
+    Name: "api.domain.com.",
+    Type: "A",
+  });
+  hasResource(stack, "AWS::Route53::RecordSet", {
+    Name: "api.domain.com.",
+    Type: "AAAA",
+  });
+  hasResource(stack, "AWS::Route53::HostedZone", {
+    Name: "domain.com.",
   });
 });
 


### PR DESCRIPTION
I ran into this issue when we upgraded from v0 to v1.

We suddenly required HostedZone lookups when previously it wasn't necessary and we started getting:

```
[Error at /prod-uk-services-PostmarkWebhookStack/PostmarkWebhookApi] User: arn:aws:iam::11111111111111:user/seed/prod-uk-infrastructure-seed-run-user is not authorized to perform: route53:ListHostedZonesByName because no identity-based policy allows the route53:ListHostedZonesByName action
  Annotations.addMessage (/tmp/seed/source/node_modules/.pnpm/aws-cdk-lib@2.24.0_constructs@10.1.41/node_modules/aws-cdk-lib/core/lib/annotations.js:1:1213)
  Annotations.addError (/tmp/seed/source/node_modules/.pnpm/aws-cdk-lib@2.24.0_constructs@10.1.41/node_modules/aws-cdk-lib/core/lib/annotations.js:1:765)
  Function.getValue (/tmp/seed/source/node_modules/.pnpm/aws-cdk-lib@2.24.0_constructs@10.1.41/node_modules/aws-cdk-lib/core/lib/context-provider.js:2:1160)
  Function.fromLookup (/tmp/seed/source/node_modules/.pnpm/aws-cdk-lib@2.24.0_constructs@10.1.41/node_modules/aws-cdk-lib/aws-route53/lib/hosted-zone.js:1:2626)
  ApiGatewayV1Api.createCustomDomain (file:///tmp/seed/source/node_modules/.pnpm/@serverless-stack+resources@1.2.22/node_modules/@serverless-stack/resources/dist/ApiGatewayV1Api.js:381:49)
  ApiGatewayV1Api.createRestApi (file:///tmp/seed/source/node_modules/.pnpm/@serverless-stack+resources@1.2.22/node_modules/@serverless-stack/resources/dist/ApiGatewayV1Api.js:259:18)
  new ApiGatewayV1Api (file:///tmp/seed/source/node_modules/.pnpm/@serverless-stack+resources@1.2.22/node_modules/@serverless-stack/resources/dist/ApiGatewayV1Api.js:62:14)
  new PostmarkWebhookStack (file:///tmp/seed/source/.build/lib/index.js:7844:21)
  Module.main (file:///tmp/seed/source/.build/lib/index.js:8744:32)
  file:///tmp/seed/source/.build/run.mjs:92:16
```

Our config is:

```typescript
    const restApi = new sst.ApiGatewayV1Api(this, restApiId, {
      customDomain: {
        domainName: 'postmark.uk.domain.com',
        cdk: {
          certificate: certificates.postmark,
          hostedZone: ukHostedZone
        }
      },
    });
```

I think if a `cdk.hostedZone` is provided then there should be no lookup required as it's already there. I added a validation for this.

## Test weirdness

I also discovered that the tests may be incorrect due to this code leaking between tests:

```
  route53.HostedZone.fromLookup = vi
    .fn()
    .mockImplementation((scope, id, { domainName }) => {
      return new route53.HostedZone(scope, id, { zoneName: domainName });
    });
```

This is easy to try out, just add `.skip` to all tests that use this mock and watch other tests fail.

Any better way to reset the `route53.HostedZone.fromLookup` vitest mock?